### PR TITLE
feature : 전반적인 프론트 UI 및 모임 화면 재구성

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,7 +75,6 @@
 }
 
 @theme inline {
-  /* optional: --font-sans, --font-serif, --font-mono if they are applied in the layout.tsx */
   --font-sans: 'Geist', 'Geist Fallback';
   --font-mono: 'Geist Mono', 'Geist Mono Fallback';
   --color-background: var(--background);
@@ -145,7 +144,7 @@
   }
 }
 
-@keyframes fade-in {
+@keyframes fadeIn {
   from {
     opacity: 0;
   }
@@ -154,70 +153,12 @@
   }
 }
 
-@keyframes fade-out {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes slide-in-from-top {
-  from {
-    transform: translateY(-100%);
-  }
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes slide-in-from-bottom {
+@keyframes slideInFromBottom {
   from {
     transform: translateY(100%);
   }
   to {
     transform: translateY(0);
-  }
-}
-
-@keyframes slide-in-from-left {
-  from {
-    transform: translateX(-100%);
-  }
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes slide-in-from-right {
-  from {
-    transform: translateX(100%);
-  }
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes zoom-in {
-  from {
-    opacity: 0;
-    transform: scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: scale(1);
-  }
-}
-
-@keyframes zoom-out {
-  from {
-    opacity: 1;
-    transform: scale(1);
-  }
-  to {
-    opacity: 0;
-    transform: scale(0.95);
   }
 }
 
@@ -247,22 +188,28 @@
   animation: accordion-up 0.2s ease-out;
 }
 
-.animate-fade-in {
-  animation: fade-in 0.2s ease-out;
-}
-
-.animate-fade-out {
-  animation: fade-out 0.2s ease-out;
-}
-
 .animate-spin {
   animation: spin 1s linear infinite;
 }
 
 .animate-in {
-  animation: fade-in 0.2s ease-out, zoom-in 0.2s ease-out;
+  animation-duration: 0.2s;
+  animation-timing-function: ease-out;
+  animation-fill-mode: both;
 }
 
-.animate-out {
-  animation: fade-out 0.2s ease-out, zoom-out 0.2s ease-out;
+.fade-in {
+  animation-name: fadeIn;
+}
+
+.slide-in-from-bottom {
+  animation-name: slideInFromBottom;
+}
+
+.duration-200 {
+  animation-duration: 200ms;
+}
+
+.duration-300 {
+  animation-duration: 300ms;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Calendar } from '@/components/calendar';
 import { EventDialog } from '@/components/event-dialog';
@@ -20,6 +20,7 @@ import {
 import { mapRawToCalendarEvent } from '@/lib/calendar-utils';
 import type { RawCalendarEvent, Event } from '@/types/calendar';
 import { useEventRefresh } from '@/hooks/useEventRefresh';
+import { fetchEvents } from '@/app/api/calendar/calendar';
 
 export default function HomePage() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -37,12 +38,11 @@ export default function HomePage() {
 
   const isMobile = useIsMobile();
 
-  // 🔥 전역 refresh 트리거
   const { trigger } = useEventRefresh();
 
   const initialLoadDoneRef = useRef(false);
+  const loadedMonthsRef = useRef<Set<string>>(new Set());
 
-  // 서버 응답 → 화면용 이벤트로 변환
   const mapRaw = (list: RawCalendarEvent[]): Event[] =>
     list
       .map((raw, idx) => {
@@ -62,7 +62,6 @@ export default function HomePage() {
         (a: Event, b: Event) => a.startDate.getTime() - b.startDate.getTime()
       );
 
-  // ✅ trigger가 바뀔 때마다 전체 이벤트 다시 로딩 (초기 로드 또는 강제 새로고침)
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -73,6 +72,12 @@ export default function HomePage() {
         if (cancelled) return;
         setEvents(mapRaw(raw as RawCalendarEvent[]));
         initialLoadDoneRef.current = true;
+        raw.forEach((evt: RawCalendarEvent) => {
+          if (evt.start) {
+            const d = new Date(evt.start);
+            loadedMonthsRef.current.add(`${d.getFullYear()}-${d.getMonth()}`);
+          }
+        });
       } catch (err: any) {
         if (!cancelled) {
           setError(err?.message ?? '데이터를 불러올 수 없습니다');
@@ -92,7 +97,6 @@ export default function HomePage() {
     const sseUrl = `${API_BASE}/api/sse/events`;
     const es = new EventSource(sseUrl);
 
-    // SSE는 에러 감지만 - 성공적인 업데이트는 낙관적 UI로 처리
     es.onerror = () => {
       console.warn('[v0] SSE 연결 끊김 - 캘린더 갱신 필요');
       es.close();
@@ -103,9 +107,64 @@ export default function HomePage() {
     };
   }, []);
 
-  // =============================
-  // 캘린더 인터랙션 핸들러들
-  // =============================
+  const handleMonthChange = useCallback(
+    async (months: Date[]) => {
+      if (!initialLoadDoneRef.current) return;
+
+      const newMonths = months.filter((m) => {
+        const key = `${m.getFullYear()}-${m.getMonth()}`;
+        return !loadedMonthsRef.current.has(key);
+      });
+
+      if (newMonths.length === 0) return;
+
+      const sortedMonths = [...newMonths].sort(
+        (a, b) => a.getTime() - b.getTime()
+      );
+      const startMonth = sortedMonths[0];
+      const endMonth = sortedMonths[sortedMonths.length - 1];
+
+      const startDate = new Date(
+        startMonth.getFullYear(),
+        startMonth.getMonth(),
+        1
+      );
+      const endDate = new Date(
+        endMonth.getFullYear(),
+        endMonth.getMonth() + 1,
+        0,
+        23,
+        59,
+        59,
+        999
+      );
+
+      try {
+        const raw = await fetchEvents({
+          start: startDate.toISOString(),
+          end: endDate.toISOString(),
+        });
+
+        newMonths.forEach((m) => {
+          loadedMonthsRef.current.add(`${m.getFullYear()}-${m.getMonth()}`);
+        });
+
+        if (raw.length > 0) {
+          setEvents((prev) => {
+            const existingIds = new Set(prev.map((e) => e.id));
+            const newEvents = mapRaw(raw).filter((e) => !existingIds.has(e.id));
+            if (newEvents.length === 0) return prev;
+            return [...prev, ...newEvents].sort(
+              (a, b) => a.startDate.getTime() - b.startDate.getTime()
+            );
+          });
+        }
+      } catch (err) {
+        console.warn('[v0] 추가 이벤트 로드 실패:', err);
+      }
+    },
+    [colorMap]
+  );
 
   const handleEventClick = (event: Event) => {
     setSelectedEvent(event);
@@ -137,21 +196,15 @@ export default function HomePage() {
     setIsDialogOpen(true);
   };
 
-  // ✅ 동기화 버튼: 구글 OAuth 시작
   const syncNow = () => {
     const base = API_BASE || 'http://localhost:8080';
     window.location.href = `${base}/oauth2/authorization/google`;
   };
 
-  // =============================
-  // 저장 / 삭제 (낙관적 UI 로직)
-  // =============================
-
   const handleSaveEvent = async (event: Event) => {
     setIsDialogOpen(false);
     setIsEditMode(false);
 
-    // API 요청에 필요한 payload 미리 준비
     const formatToISO = (
       date: Date,
       allDay: boolean,
@@ -181,7 +234,6 @@ export default function HomePage() {
       color: event.color,
     };
 
-    // 임시 ID 및 가짜 이벤트 생성
     const tempId = selectedEvent ? selectedEvent.id : `temp-${Date.now()}`;
     const optimisticEvent: Event = { ...event, id: tempId };
 
@@ -196,11 +248,9 @@ export default function HomePage() {
       setEvents((prev) => [...prev, optimisticEvent]);
     }
 
-    // 백그라운드에서 API 호출 진행
     try {
       if (selectedEvent) {
         const realEvent = await updateCalendarEvent(tempId, requestPayload);
-        // 서버 응답으로 ID나 다른 속성이 변경되었을 수 있으므로 업데이트
         setEvents((prev) =>
           prev.map((e) => (e.id === tempId ? mapRaw([realEvent])[0] : e))
         );
@@ -209,7 +259,6 @@ export default function HomePage() {
         );
       } else {
         const realEvent = await createCalendarEvent(requestPayload);
-        // 임시 ID를 실제 서버 ID로 교체
         setEvents((prev) =>
           prev.map((e) => (e.id === tempId ? mapRaw([realEvent])[0] : e))
         );
@@ -252,10 +301,6 @@ export default function HomePage() {
       setEvents(previousEvents);
     }
   };
-
-  // =============================
-  // 렌더
-  // =============================
 
   return (
     <ProtectedRoute>
@@ -301,6 +346,7 @@ export default function HomePage() {
                 onEventDoubleClick={handleEventClick}
                 onDateRangeSelect={handleDateRangeSelect}
                 onCreateNewEvent={handleCreateNewEventFromBottomSheet}
+                onMonthChange={handleMonthChange}
               />
             )}
           </div>

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import {
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+  useCallback,
+  useTransition,
+} from 'react';
 import { ChevronLeft, ChevronRight, X, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -40,6 +47,14 @@ const isSameDay = (a: Date, b: Date) =>
   a.getMonth() === b.getMonth() &&
   a.getDate() === b.getDate();
 const monthKey = (d: Date) => `${d.getFullYear()}-${d.getMonth()}`;
+
+const filterDuplicateMonths = (
+  existingMonths: Date[],
+  newMonths: Date[]
+): Date[] => {
+  const existingKeys = new Set(existingMonths.map(monthKey));
+  return newMonths.filter((m) => !existingKeys.has(monthKey(m)));
+};
 
 const isMultiDayEvent = (evt: CalendarEvent): boolean => {
   if (!evt.allDay) return false;
@@ -81,7 +96,6 @@ const assignRowsToMultiDayEvents = (
     const eventStart = startOfDay(new Date(event.startDate));
     const eventEnd = startOfDay(new Date(event.endDate));
 
-    // 이 주에서의 시작/끝 계산
     const visibleStart =
       eventStart < startOfDay(weekStart) ? startOfDay(weekStart) : eventStart;
     const visibleEnd = eventEnd > weekEnd ? weekEnd : eventEnd;
@@ -94,7 +108,6 @@ const assignRowsToMultiDayEvents = (
     );
     const span = endCol - startCol + 1;
 
-    // 빈 row 찾기
     let assignedRow = -1;
     for (let i = 0; i < rows.length; i++) {
       const rowEvents = rows[i];
@@ -143,6 +156,7 @@ type Props = {
   onEventDoubleClick: (event: CalendarEvent) => void;
   onDateRangeSelect: (start: Date, end: Date) => void;
   onCreateNewEvent?: (date: Date) => void;
+  onMonthChange?: (months: Date[]) => void;
 };
 
 /* ===== 컴포넌트 ===== */
@@ -151,9 +165,10 @@ export function Calendar({
   onEventDoubleClick,
   onDateRangeSelect,
   onCreateNewEvent,
+  onMonthChange,
 }: Props) {
   // 상태
-  const [currentDate, setCurrentDate] = useState<Date>(new Date()); // 가운데(기준) 달
+  const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const [displayMonths, setDisplayMonths] = useState<Date[]>([]);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
@@ -166,25 +181,74 @@ export function Calendar({
   const [dayModalDate, setDayModalDate] = useState<Date | null>(null);
   const [dayModalEvents, setDayModalEvents] = useState<CalendarEvent[]>([]);
 
-  // 드래그(포인터) 상태
-  const [isDragging, setIsDragging] = useState<boolean>(false);
-  const [dragStart, setDragStart] = useState<Date | null>(null);
-  const [dragEnd, setDragEnd] = useState<Date | null>(null);
+  const dragStateRef = useRef<{
+    isDragging: boolean;
+    dragStart: Date | null;
+    dragEnd: Date | null;
+  }>({
+    isDragging: false,
+    dragStart: null,
+    dragEnd: null,
+  });
+
+  const [dragRange, setDragRange] = useState<{ start: Date; end: Date } | null>(
+    null
+  );
+  const dragUpdateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
   const touchStartPosRef = useRef<{ x: number; y: number } | null>(null);
   const dialogJustOpenedRef = useRef(false);
 
+  const [isPending, startTransition] = useTransition();
+
   // 성능 파라미터
-  const INITIAL_BEFORE = 2; // 현재 달 기준 앞쪽 렌더 개월
-  const INITIAL_AFTER = 2; // 현재 달 기준 뒤쪽 렌더 개월
-  const LOAD_CHUNK = 1; // 스크롤 시 한 번에 추가할 개월
+  const INITIAL_BEFORE = 2;
+  const INITIAL_AFTER = 2;
+  const LOAD_CHUNK = 1;
 
   // refs
   const containerRef = useRef<HTMLDivElement>(null);
-  const monthRefs = useRef<Map<string, HTMLDivElement>>(new Map()); // 각 달 Card ref
+  const monthRefs = useRef<Map<string, HTMLDivElement>>(new Map());
   const isUpdatingScrollRef = useRef(false);
   const isMobile = useIsMobile();
 
-  /* 1) 초기 월 윈도우 만들기 (데이터 fetching 제거) */
+  const eventsByMonth = useMemo(() => {
+    const map = new Map<string, CalendarEvent[]>();
+
+    events.forEach((evt) => {
+      const startDate = new Date(evt.startDate);
+      const endDate = new Date(evt.endDate);
+
+      // 이벤트가 걸치는 모든 월에 추가
+      const current = new Date(
+        startDate.getFullYear(),
+        startDate.getMonth(),
+        1
+      );
+      const endMonth = new Date(endDate.getFullYear(), endDate.getMonth(), 1);
+
+      while (current <= endMonth) {
+        const key = monthKey(current);
+        if (!map.has(key)) {
+          map.set(key, []);
+        }
+        map.get(key)!.push(evt);
+        current.setMonth(current.getMonth() + 1);
+      }
+    });
+
+    return map;
+  }, [events]);
+
+  const getEventsForMonth = useCallback(
+    (monthDate: Date): CalendarEvent[] => {
+      const key = monthKey(monthDate);
+      return eventsByMonth.get(key) || [];
+    },
+    [eventsByMonth]
+  );
+
+  /* 1) 초기 월 윈도우 만들기 */
   useEffect(() => {
     const now = new Date();
     const months: Date[] = [];
@@ -193,9 +257,11 @@ export function Calendar({
     }
     setDisplayMonths(months);
     setCurrentDate(now);
+
+    onMonthChange?.(months);
   }, []);
 
-  /* 2) 현재 달 카드로 스크롤(초기 위치를 가운데로) → 위/아래 확장 가능 */
+  /* 2) 현재 달 카드로 스크롤 */
   useEffect(() => {
     if (!isInitialLoad || displayMonths.length === 0) return;
 
@@ -203,7 +269,7 @@ export function Calendar({
     const el = monthRefs.current.get(key);
     if (el && containerRef.current) {
       el.scrollIntoView({ block: 'start', behavior: 'auto' });
-      containerRef.current.scrollTop += 16; // top trigger 여유
+      containerRef.current.scrollTop += 16;
       setIsInitialLoad(false);
     }
   }, [displayMonths, currentDate, isInitialLoad]);
@@ -214,164 +280,257 @@ export function Calendar({
   const prevMonth = () => setCurrentDate(new Date(year, month - 1, 1));
   const nextMonth = () => setCurrentDate(new Date(year, month + 1, 1));
 
-  /* 4) 스크롤로 월 동적 추가 */
-  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
-    if (isUpdatingScrollRef.current) {
-      return;
-    }
-
-    const container = e.currentTarget;
-    const scrollTop = container.scrollTop;
-
-    if (displayMonths.length === 0) return;
-
-    // 상단 가까우면 이전 달 추가
-    if (scrollTop < 120) {
-      isUpdatingScrollRef.current = true;
-
-      const first = displayMonths[0];
-      const toAdd: Date[] = [];
-      for (let i = LOAD_CHUNK; i >= 1; i--) {
-        const m = addMonths(first, -i);
-        if (!displayMonths.some((d) => monthKey(d) === monthKey(m)))
-          toAdd.push(m);
+  /* 4) 스크롤로 월 동적 추가 - useTransition으로 최적화 */
+  const handleScroll = useCallback(
+    (e: React.UIEvent<HTMLDivElement>) => {
+      if (isUpdatingScrollRef.current) {
+        return;
       }
 
-      if (toAdd.length > 0) {
+      const container = e.currentTarget;
+      const scrollTop = container.scrollTop;
+
+      if (displayMonths.length === 0) return;
+
+      // 상단 가까우면 이전 달 추가
+      if (scrollTop < 120) {
+        isUpdatingScrollRef.current = true;
+
+        const first = displayMonths[0];
+        const toAdd: Date[] = [];
+        for (let i = LOAD_CHUNK; i >= 1; i--) {
+          toAdd.push(addMonths(first, -i));
+        }
+
         const previousScrollHeight = container.scrollHeight;
 
-        setDisplayMonths((prev) => [...toAdd, ...prev]);
+        startTransition(() => {
+          setDisplayMonths((prev) => {
+            const filtered = filterDuplicateMonths(prev, toAdd);
+            if (filtered.length === 0) return prev;
+            const newMonths = [...filtered, ...prev];
+            onMonthChange?.(newMonths);
+            return newMonths;
+          });
+        });
 
         // DOM 업데이트 후 스크롤 위치 보정
         requestAnimationFrame(() => {
-          const newScrollHeight = container.scrollHeight;
-          const addedHeight = newScrollHeight - previousScrollHeight;
-          container.scrollTop = scrollTop + addedHeight;
-          isUpdatingScrollRef.current = false;
+          requestAnimationFrame(() => {
+            const newScrollHeight = container.scrollHeight;
+            const addedHeight = newScrollHeight - previousScrollHeight;
+            container.scrollTop = scrollTop + addedHeight;
+            isUpdatingScrollRef.current = false;
+          });
         });
+      }
+
+      // 하단 가까우면 다음 달 추가
+      const { scrollHeight, clientHeight } = container;
+      if (scrollTop + clientHeight > scrollHeight - 200) {
+        const last = displayMonths[displayMonths.length - 1];
+        const toAdd: Date[] = [];
+        for (let i = 1; i <= LOAD_CHUNK; i++) {
+          toAdd.push(addMonths(last, i));
+        }
+        startTransition(() => {
+          setDisplayMonths((prev) => {
+            const filtered = filterDuplicateMonths(prev, toAdd);
+            if (filtered.length === 0) return prev;
+            const newMonths = [...prev, ...filtered];
+            onMonthChange?.(newMonths);
+            return newMonths;
+          });
+        });
+      }
+    },
+    [displayMonths, onMonthChange]
+  );
+
+  /* 5) 드래그 범위 체크 */
+  const isDateInDragRange = useCallback(
+    (date: Date): boolean => {
+      if (!dragRange) return false;
+      const s =
+        dragRange.start < dragRange.end ? dragRange.start : dragRange.end;
+      const e =
+        dragRange.start < dragRange.end ? dragRange.end : dragRange.start;
+      const d = startOfDay(date);
+      return d >= startOfDay(s) && d <= startOfDay(e);
+    },
+    [dragRange]
+  );
+
+  const updateDragRange = useCallback(
+    (start: Date | null, end: Date | null) => {
+      if (dragUpdateTimeoutRef.current) {
+        clearTimeout(dragUpdateTimeoutRef.current);
+      }
+
+      if (start && end) {
+        // 즉시 업데이트 (throttle 없이)
+        setDragRange({ start, end });
       } else {
-        isUpdatingScrollRef.current = false;
+        setDragRange(null);
       }
-    }
+    },
+    []
+  );
 
-    // 하단 가까우면 다음 달 추가
-    const { scrollHeight, clientHeight } = container;
-    if (scrollTop + clientHeight > scrollHeight - 200) {
-      const last = displayMonths[displayMonths.length - 1];
-      const toAdd: Date[] = [];
-      for (let i = 1; i <= LOAD_CHUNK; i++) {
-        const m = addMonths(last, i);
-        if (!displayMonths.some((d) => monthKey(d) === monthKey(m)))
-          toAdd.push(m);
+  const handlePointerDown = useCallback(
+    (date: Date, e: React.PointerEvent) => {
+      if (bottomSheetOpenRef.current) return;
+      const target = e.target as HTMLElement;
+      if (target.closest('[data-event-clickable]')) return;
+
+      touchStartPosRef.current = { x: e.clientX, y: e.clientY };
+
+      if (isMobile) {
+        return;
       }
-      if (toAdd.length) {
-        setDisplayMonths((prev) => [...prev, ...toAdd]);
+
+      // PC: 드래그 시작 - ref 사용
+      dragStateRef.current = {
+        isDragging: true,
+        dragStart: date,
+        dragEnd: date,
+      };
+      updateDragRange(date, date);
+    },
+    [isMobile, updateDragRange]
+  );
+
+  const handlePointerMove = useCallback(
+    (date: Date) => {
+      if (isMobile) return;
+      if (dragStateRef.current.isDragging) {
+        dragStateRef.current.dragEnd = date;
+        updateDragRange(dragStateRef.current.dragStart, date);
       }
-    }
-  };
+    },
+    [isMobile, updateDragRange]
+  );
 
-  /* 5) 드래그(포인터)로 날짜 범위 선택 — 모바일/PC 공통 */
-  const isDateInDragRange = (date: Date): boolean => {
-    if (!isDragging || !dragStart || !dragEnd) return false;
-    const s = dragStart < dragEnd ? dragStart : dragEnd;
-    const e = dragStart < dragEnd ? dragEnd : dragStart;
-    const d = startOfDay(date);
-    return d >= startOfDay(s) && d <= startOfDay(e);
-  };
-
-  const handlePointerDown = (date: Date, e: React.PointerEvent) => {
-    if (bottomSheetOpenRef.current) return;
-    const target = e.target as HTMLElement;
-    if (target.closest('[data-event-clickable]')) return;
-    touchStartPosRef.current = { x: e.clientX, y: e.clientY };
-    setIsDragging(true);
-    setDragStart(date);
-    setDragEnd(date);
-  };
-
-  const handlePointerMove = (date: Date) => {
-    if (isDragging) {
-      setDragEnd(date);
-    }
-  };
-
-  const handlePointerUp = (date: Date, e: React.PointerEvent) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('[data-event-clickable]')) {
-      setIsDragging(false);
-      setDragStart(null);
-      setDragEnd(null);
-      return;
-    }
-
-    if (touchStartPosRef.current) {
-      const dx = Math.abs(e.clientX - touchStartPosRef.current.x);
-      const dy = Math.abs(e.clientY - touchStartPosRef.current.y);
-      if (dx > 10 || dy > 10) {
-        setIsDragging(false);
-        setDragStart(null);
-        setDragEnd(null);
+  const handlePointerUp = useCallback(
+    (date: Date, e: React.PointerEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('[data-event-clickable]')) {
+        dragStateRef.current = {
+          isDragging: false,
+          dragStart: null,
+          dragEnd: null,
+        };
+        updateDragRange(null, null);
         touchStartPosRef.current = null;
         return;
       }
-    }
 
-    if (isMobile) {
-      const cellStart = startOfDay(date);
-      const cellEnd = endOfDay(date);
-
-      const multiDayEventsForCell = getMultiDayEventsForDate(events, date);
-
-      const singleDayAllDayEvents = events.filter((evt: CalendarEvent) => {
-        if (!evt.allDay || isMultiDayEvent(evt)) return false;
-        const s = startOfDay(new Date(evt.startDate));
-        return isSameDay(s, date);
-      });
-
-      const timedSingles = events.filter((evt: CalendarEvent) => {
-        if (evt.allDay) return false;
-        const s = new Date(evt.startDate);
-        const ev = new Date(evt.endDate);
-        return (
-          (s >= cellStart && s <= cellEnd) ||
-          (ev >= cellStart && ev <= cellEnd) ||
-          (s <= cellStart && ev >= cellEnd)
-        );
-      });
-
-      const allDayEventsForDate = [
-        ...multiDayEventsForCell,
-        ...singleDayAllDayEvents,
-        ...timedSingles,
-      ];
-
-      if (allDayEventsForDate.length > 0) {
-        setSelectedDate(date);
-        setBottomSheetEvents(allDayEventsForDate);
-        bottomSheetOpenRef.current = true;
-        setIsDragging(false);
-        setDragStart(null);
-        setDragEnd(null);
+      if (isMobile) {
+        if (touchStartPosRef.current) {
+          const dx = Math.abs(e.clientX - touchStartPosRef.current.x);
+          const dy = Math.abs(e.clientY - touchStartPosRef.current.y);
+          if (dx > 10 || dy > 10) {
+            touchStartPosRef.current = null;
+            return;
+          }
+        }
         touchStartPosRef.current = null;
+
+        const cellStart = startOfDay(date);
+        const cellEnd = endOfDay(date);
+
+        const multiDayEventsForCell = getMultiDayEventsForDate(events, date);
+
+        const singleDayAllDayEvents = events.filter((evt: CalendarEvent) => {
+          if (!evt.allDay || isMultiDayEvent(evt)) return false;
+          const s = startOfDay(new Date(evt.startDate));
+          return isSameDay(s, date);
+        });
+
+        const timedSingles = events.filter((evt: CalendarEvent) => {
+          if (evt.allDay) return false;
+          const s = new Date(evt.startDate);
+          const ev = new Date(evt.endDate);
+          return (
+            (s >= cellStart && s <= cellEnd) ||
+            (ev >= cellStart && ev <= cellEnd) ||
+            (s <= cellStart && ev >= cellEnd)
+          );
+        });
+
+        const allDayEventsForDate = [
+          ...multiDayEventsForCell,
+          ...singleDayAllDayEvents,
+          ...timedSingles,
+        ];
+
+        if (allDayEventsForDate.length > 0) {
+          setSelectedDate(date);
+          setBottomSheetEvents(allDayEventsForDate);
+          bottomSheetOpenRef.current = true;
+        }
         return;
       }
-    }
 
-    if (isDragging && dragStart) {
-      const s = dragStart < date ? dragStart : date;
-      const e = dragStart < date ? date : dragStart;
-      dialogJustOpenedRef.current = true;
-      setTimeout(() => {
-        dialogJustOpenedRef.current = false;
-      }, 300);
-      onDateRangeSelect(s, e);
-    }
+      if (touchStartPosRef.current) {
+        const dx = Math.abs(e.clientX - touchStartPosRef.current.x);
+        const dy = Math.abs(e.clientY - touchStartPosRef.current.y);
+        if (dx > 10 || dy > 10) {
+          if (
+            dragStateRef.current.isDragging &&
+            dragStateRef.current.dragStart
+          ) {
+            const s =
+              dragStateRef.current.dragStart < date
+                ? dragStateRef.current.dragStart
+                : date;
+            const ev =
+              dragStateRef.current.dragStart < date
+                ? date
+                : dragStateRef.current.dragStart;
+            dialogJustOpenedRef.current = true;
+            setTimeout(() => {
+              dialogJustOpenedRef.current = false;
+            }, 300);
+            onDateRangeSelect(s, ev);
+          }
+          dragStateRef.current = {
+            isDragging: false,
+            dragStart: null,
+            dragEnd: null,
+          };
+          updateDragRange(null, null);
+          touchStartPosRef.current = null;
+          return;
+        }
+      }
 
-    setIsDragging(false);
-    setDragStart(null);
-    setDragEnd(null);
-    touchStartPosRef.current = null;
-  };
+      if (dragStateRef.current.isDragging && dragStateRef.current.dragStart) {
+        const s =
+          dragStateRef.current.dragStart < date
+            ? dragStateRef.current.dragStart
+            : date;
+        const ev =
+          dragStateRef.current.dragStart < date
+            ? date
+            : dragStateRef.current.dragStart;
+        dialogJustOpenedRef.current = true;
+        setTimeout(() => {
+          dialogJustOpenedRef.current = false;
+        }, 300);
+        onDateRangeSelect(s, ev);
+      }
+
+      dragStateRef.current = {
+        isDragging: false,
+        dragStart: null,
+        dragEnd: null,
+      };
+      updateDragRange(null, null);
+      touchStartPosRef.current = null;
+    },
+    [events, isMobile, onDateRangeSelect, updateDragRange]
+  );
 
   const fmtTime = (d: Date) =>
     `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(
@@ -381,469 +540,469 @@ export function Calendar({
 
   const MAX_VISIBLE_EVENTS = 3;
 
-  /* 6) 월 렌더 */
-  const renderMonth = (date: Date) => {
-    const y = date.getFullYear();
-    const m = date.getMonth();
-    const grid = buildMonthGrid(y, m);
+  /* 6) 월 렌더 - useMemo로 최적화 */
+  const renderMonth = useCallback(
+    (date: Date) => {
+      const y = date.getFullYear();
+      const m = date.getMonth();
+      const grid = buildMonthGrid(y, m);
 
-    return (
-      <Card
-        key={monthKey(date)}
-        ref={(el) => {
-          if (el) monthRefs.current.set(monthKey(date), el);
-          else monthRefs.current.delete(monthKey(date));
-        }}
-        className="overflow-hidden shadow-lg select-none mb-4"
-      >
-        {/* 헤더 (현재 가운데 월일 때만 좌우 버튼) */}
-        <div className="flex items-center justify-between bg-gradient-to-r from-primary/10 to-primary/5 p-4">
-          {date.getMonth() === currentDate.getMonth() &&
-          date.getFullYear() === currentDate.getFullYear() ? (
-            <>
-              {!isMobile && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={prevMonth}
-                  className="hover:bg-primary/10"
-                  aria-label="prev"
-                >
-                  <ChevronLeft className="h-5 w-5" />
-                </Button>
-              )}
+      const monthEvents = getEventsForMonth(date);
+
+      return (
+        <Card
+          key={monthKey(date)}
+          ref={(el) => {
+            if (el) monthRefs.current.set(monthKey(date), el);
+            else monthRefs.current.delete(monthKey(date));
+          }}
+          className="overflow-hidden shadow-lg select-none mb-4"
+        >
+          {/* 헤더 */}
+          <div className="flex items-center justify-between bg-gradient-to-r from-primary/10 to-primary/5 p-4">
+            {date.getMonth() === month && date.getFullYear() === year ? (
+              <>
+                {!isMobile && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={prevMonth}
+                    className="hover:bg-primary/10"
+                    aria-label="prev"
+                  >
+                    <ChevronLeft className="h-5 w-5" />
+                  </Button>
+                )}
+                <h2 className="text-lg font-bold text-foreground flex-1 text-center">
+                  {y}년 {m + 1}월
+                </h2>
+                {!isMobile && (
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={nextMonth}
+                    className="hover:bg-primary/10"
+                    aria-label="next"
+                  >
+                    <ChevronRight className="h-5 w-5" />
+                  </Button>
+                )}
+              </>
+            ) : (
               <h2 className="text-lg font-bold text-foreground flex-1 text-center">
                 {y}년 {m + 1}월
               </h2>
-              {!isMobile && (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={nextMonth}
-                  className="hover:bg-primary/10"
-                  aria-label="next"
-                >
-                  <ChevronRight className="h-5 w-5" />
-                </Button>
-              )}
-            </>
-          ) : (
-            <h2 className="text-lg font-bold text-foreground flex-1 text-center">
-              {y}년 {m + 1}월
-            </h2>
-          )}
-        </div>
-
-        <div className="p-4">
-          {/* 요일 라벨 */}
-          <div className="mb-3 grid grid-cols-7 gap-1 text-center">
-            {['일', '월', '화', '수', '목', '금', '토'].map((day, idx) => (
-              <div
-                key={day}
-                className={`text-sm font-bold ${
-                  idx === 0
-                    ? 'text-red-500'
-                    : idx === 6
-                    ? 'text-blue-500'
-                    : 'text-muted-foreground'
-                }`}
-              >
-                {day}
-              </div>
-            ))}
+            )}
           </div>
 
-          {/* 주 단위 렌더 */}
-          <div className="space-y-2">
-            {grid.map((week, weekIdx) => {
-              const firstValidDate = week.find((d) => d !== null);
-              const weekStart = firstValidDate
-                ? startOfDay(addDays(firstValidDate, -firstValidDate.getDay()))
-                : new Date();
+          <div className="p-4">
+            {/* 요일 라벨 */}
+            <div className="mb-3 grid grid-cols-7 gap-1 text-center">
+              {['일', '월', '화', '수', '목', '금', '토'].map((day, idx) => (
+                <div
+                  key={day}
+                  className={`text-sm font-bold ${
+                    idx === 0
+                      ? 'text-red-500'
+                      : idx === 6
+                      ? 'text-blue-500'
+                      : 'text-muted-foreground'
+                  }`}
+                >
+                  {day}
+                </div>
+              ))}
+            </div>
 
-              const eventToRow = assignRowsToMultiDayEvents(events, weekStart);
+            {/* 주 단위 렌더 */}
+            <div className="space-y-2">
+              {grid.map((week, weekIdx) => {
+                const firstValidDate = week.find((d) => d !== null);
+                const weekStart = firstValidDate
+                  ? startOfDay(
+                      addDays(firstValidDate, -firstValidDate.getDay())
+                    )
+                  : new Date();
 
-              return (
-                <div key={`week-${weekIdx}`} className="relative">
-                  {/* 날짜 셀 */}
-                  <div className="grid grid-cols-7 gap-1">
-                    {week.map((cellDate, colIdx) => {
-                      if (!cellDate) return <div key={`empty-${colIdx}`} />;
+                const eventToRow = assignRowsToMultiDayEvents(
+                  monthEvents,
+                  weekStart
+                );
 
-                      const now = new Date();
-                      const today = isSameDay(cellDate, now);
-                      const inDrag = isDateInDragRange(cellDate);
+                return (
+                  <div key={`week-${weekIdx}`} className="relative">
+                    <div className="grid grid-cols-7 gap-1">
+                      {week.map((cellDate, colIdx) => {
+                        if (!cellDate) return <div key={`empty-${colIdx}`} />;
 
-                      const cellStart = startOfDay(cellDate);
-                      const cellEnd = endOfDay(cellDate);
+                        const now = new Date();
+                        const today = isSameDay(cellDate, now);
+                        const inDrag = isDateInDragRange(cellDate);
 
-                      const multiDayEventsForCell: {
-                        event: CalendarEvent;
-                        row: number;
-                        startCol: number;
-                        span: number;
-                        isWeekStart: boolean;
-                      }[] = [];
+                        const cellStart = startOfDay(cellDate);
+                        const cellEnd = endOfDay(cellDate);
 
-                      eventToRow.forEach(({ row, event, startCol, span }) => {
-                        if (startCol === colIdx) {
-                          const eventStart = startOfDay(
-                            new Date(event.startDate)
-                          );
-                          const isWeekStart =
-                            colIdx === 0 && eventStart < weekStart;
-                          multiDayEventsForCell.push({
-                            event,
-                            row,
-                            startCol,
-                            span,
-                            isWeekStart,
-                          });
-                        }
-                      });
+                        const multiDayEventsForCell: {
+                          event: CalendarEvent;
+                          row: number;
+                          startCol: number;
+                          span: number;
+                          isWeekStart: boolean;
+                        }[] = [];
 
-                      const singleDayAllDayEvents = events.filter(
-                        (evt: CalendarEvent) => {
-                          if (!evt.allDay || isMultiDayEvent(evt)) return false;
-                          const s = startOfDay(new Date(evt.startDate));
-                          return isSameDay(s, cellDate);
-                        }
-                      );
+                        eventToRow.forEach(({ row, event, startCol, span }) => {
+                          if (startCol === colIdx) {
+                            const eventStart = startOfDay(
+                              new Date(event.startDate)
+                            );
+                            const isWeekStart =
+                              colIdx === 0 && eventStart < weekStart;
+                            multiDayEventsForCell.push({
+                              event,
+                              row,
+                              startCol,
+                              span,
+                              isWeekStart,
+                            });
+                          }
+                        });
 
-                      const timedSingles = events
-                        .filter((evt: CalendarEvent) => {
-                          if (evt.allDay) return false;
-                          const s = startOfDay(new Date(evt.startDate));
-                          const e = new Date(evt.endDate);
-                          return (
-                            isSameDay(s, cellDate) && isSameDay(e, cellDate)
-                          );
-                        })
-                        .sort(
-                          (a, b) =>
-                            a.startDate.getTime() - b.startDate.getTime()
+                        const singleDayAllDayEvents = monthEvents.filter(
+                          (evt: CalendarEvent) => {
+                            if (!evt.allDay || isMultiDayEvent(evt))
+                              return false;
+                            const s = startOfDay(new Date(evt.startDate));
+                            return isSameDay(s, cellDate);
+                          }
                         );
 
-                      const multiDayEventsOnThisDate = getMultiDayEventsForDate(
-                        events,
-                        cellDate
-                      );
-
-                      const allDayEventsForDate = [
-                        ...multiDayEventsOnThisDate,
-                        ...singleDayAllDayEvents,
-                        ...timedSingles,
-                      ];
-
-                      // 최대 row 수 계산
-                      const maxMultiDayRows =
-                        Math.max(
-                          ...multiDayEventsForCell.map((m) => m.row),
-                          -1
-                        ) + 1;
-                      const visibleMultiDayCount = multiDayEventsForCell.filter(
-                        (m) => m.row < MAX_VISIBLE_EVENTS
-                      ).length;
-
-                      const multiDayEventsRenderedElsewhere =
-                        multiDayEventsOnThisDate.filter((evt) => {
-                          const isRenderedInThisCell =
-                            multiDayEventsForCell.some(
-                              (m) =>
-                                m.event.id === evt.id &&
-                                m.row < MAX_VISIBLE_EVENTS
+                        const timedSingles = monthEvents
+                          .filter((evt: CalendarEvent) => {
+                            if (evt.allDay) return false;
+                            const s = startOfDay(new Date(evt.startDate));
+                            const e = new Date(evt.endDate);
+                            return (
+                              isSameDay(s, cellDate) && isSameDay(e, cellDate)
                             );
-                          if (isRenderedInThisCell) return false;
+                          })
+                          .sort(
+                            (a, b) =>
+                              a.startDate.getTime() - b.startDate.getTime()
+                          );
 
-                          let isVisibleInRow = false;
-                          eventToRow.forEach(({ event, row }) => {
-                            if (
-                              event.id === evt.id &&
-                              row < MAX_VISIBLE_EVENTS
-                            ) {
-                              isVisibleInRow = true;
+                        const multiDayEventsOnThisDate =
+                          getMultiDayEventsForDate(monthEvents, cellDate);
+
+                        const allDayEventsForDate = [
+                          ...multiDayEventsOnThisDate,
+                          ...singleDayAllDayEvents,
+                          ...timedSingles,
+                        ];
+
+                        const visibleMultiDayCount =
+                          multiDayEventsForCell.filter(
+                            (m) => m.row < MAX_VISIBLE_EVENTS
+                          ).length;
+
+                        const multiDayEventsRenderedElsewhere =
+                          multiDayEventsOnThisDate.filter((evt) => {
+                            const isRenderedInThisCell =
+                              multiDayEventsForCell.some(
+                                (m) =>
+                                  m.event.id === evt.id &&
+                                  m.row < MAX_VISIBLE_EVENTS
+                              );
+                            if (isRenderedInThisCell) return false;
+
+                            let isVisibleInRow = false;
+                            eventToRow.forEach(({ event, row }) => {
+                              if (
+                                event.id === evt.id &&
+                                row < MAX_VISIBLE_EVENTS
+                              ) {
+                                isVisibleInRow = true;
+                              }
+                            });
+                            return isVisibleInRow;
+                          }).length;
+
+                        const totalVisibleMultiDay =
+                          visibleMultiDayCount +
+                          multiDayEventsRenderedElsewhere;
+
+                        const remainingSpace = Math.max(
+                          0,
+                          MAX_VISIBLE_EVENTS - totalVisibleMultiDay
+                        );
+                        const visibleSingleDay = Math.min(
+                          singleDayAllDayEvents.length,
+                          remainingSpace
+                        );
+                        const remainingSpace2 = Math.max(
+                          0,
+                          remainingSpace - visibleSingleDay
+                        );
+                        const visibleTimed = Math.min(
+                          timedSingles.length,
+                          remainingSpace2
+                        );
+
+                        const totalEventsOnDate =
+                          multiDayEventsOnThisDate.length +
+                          singleDayAllDayEvents.length +
+                          timedSingles.length;
+                        const totalVisibleOnDate =
+                          totalVisibleMultiDay +
+                          visibleSingleDay +
+                          visibleTimed;
+                        const hiddenCount =
+                          totalEventsOnDate - totalVisibleOnDate;
+
+                        return (
+                          <div
+                            key={cellDate.getTime()}
+                            className={`relative min-h-[120px] cursor-pointer rounded-lg p-2 transition-all duration-200 ${
+                              inDrag
+                                ? 'bg-primary/20 shadow-sm'
+                                : 'bg-card/50 hover:bg-accent/50 hover:shadow-md'
+                            } ${
+                              today
+                                ? 'ring-2 ring-primary ring-offset-1 bg-primary/5'
+                                : ''
+                            }`}
+                            onPointerDown={(e) =>
+                              handlePointerDown(cellDate, e)
                             }
-                          });
-                          return isVisibleInRow;
-                        }).length;
-
-                      const totalVisibleMultiDay =
-                        visibleMultiDayCount + multiDayEventsRenderedElsewhere;
-
-                      const remainingSpace = Math.max(
-                        0,
-                        MAX_VISIBLE_EVENTS - totalVisibleMultiDay
-                      );
-                      const visibleSingleDay = Math.min(
-                        singleDayAllDayEvents.length,
-                        remainingSpace
-                      );
-                      const remainingSpace2 = Math.max(
-                        0,
-                        remainingSpace - visibleSingleDay
-                      );
-                      const visibleTimed = Math.min(
-                        timedSingles.length,
-                        remainingSpace2
-                      );
-
-                      const totalEventsOnDate =
-                        multiDayEventsOnThisDate.length +
-                        singleDayAllDayEvents.length +
-                        timedSingles.length;
-                      const totalVisibleOnDate =
-                        totalVisibleMultiDay + visibleSingleDay + visibleTimed;
-                      const hiddenCount =
-                        totalEventsOnDate - totalVisibleOnDate;
-
-                      return (
-                        <div
-                          key={cellDate.getTime()}
-                          className={`relative min-h-[120px] cursor-pointer rounded-lg p-2 transition-all duration-200 ${
-                            inDrag
-                              ? 'bg-primary/20 shadow-sm'
-                              : 'bg-card/50 hover:bg-accent/50 hover:shadow-md'
-                          } ${
-                            today
-                              ? 'ring-2 ring-primary ring-offset-1 bg-primary/5'
-                              : ''
-                          }`}
-                          onPointerDown={(e) => handlePointerDown(cellDate, e)}
-                          onPointerMove={() => handlePointerMove(cellDate)}
-                          onPointerUp={(e) => handlePointerUp(cellDate, e)}
-                        >
-                          <div className="flex items-start justify-between">
-                            <span
-                              className={`text-sm font-medium ${
-                                colIdx === 0
-                                  ? 'text-red-500'
-                                  : colIdx === 6
-                                  ? 'text-blue-500'
-                                  : ''
-                              }`}
-                            >
-                              {cellDate.getDate()}
-                            </span>
-                            {onCreateNewEvent && (
-                              <button
-                                data-event-clickable
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  onCreateNewEvent(cellDate);
-                                }}
-                                className="opacity-0 group-hover:opacity-100 hover:opacity-100 focus:opacity-100 p-0.5 rounded hover:bg-accent transition-opacity"
+                            onPointerMove={() => handlePointerMove(cellDate)}
+                            onPointerUp={(e) => handlePointerUp(cellDate, e)}
+                          >
+                            <div className="flex items-start justify-between">
+                              <span
+                                className={`text-sm font-medium ${
+                                  colIdx === 0
+                                    ? 'text-red-500'
+                                    : colIdx === 6
+                                    ? 'text-blue-500'
+                                    : ''
+                                }`}
                               >
-                                <Plus className="w-3 h-3 text-muted-foreground" />
-                              </button>
-                            )}
-                          </div>
-
-                          {isMobile && allDayEventsForDate.length > 0 ? (
-                            <div className="flex flex-wrap gap-0.5 mt-1">
-                              {allDayEventsForDate
-                                .slice(0, 6)
-                                .map((evt, idx) => (
-                                  <div
-                                    key={`dot-${evt.id}-${idx}`}
-                                    className={`w-1.5 h-1.5 rounded-full ${evt.color}`}
-                                    title={evt.title}
-                                  />
-                                ))}
-                              {allDayEventsForDate.length > 6 && (
-                                <div className="text-[10px] text-muted-foreground ml-1">
-                                  +{allDayEventsForDate.length - 6}
-                                </div>
-                              )}
-                            </div>
-                          ) : (
-                            <>
-                              {multiDayEventsForCell
-                                .filter((m) => m.row < MAX_VISIBLE_EVENTS)
-                                .map(
-                                  ({ event: evt, row, span, isWeekStart }) => {
-                                    const widthPercent = span * 100;
-                                    const gapAdjustment = (span - 1) * 4;
-                                    const topPosition = 32 + row * 22;
-
-                                    return (
-                                      <div
-                                        key={`multi-${
-                                          evt.id
-                                        }-${cellDate.getTime()}`}
-                                        data-event-clickable
-                                        className={`${
-                                          evt.color
-                                        } absolute left-2 right-[-4px] ${
-                                          isWeekStart
-                                            ? 'rounded-l-none'
-                                            : 'rounded-l-md'
-                                        } rounded-r-md px-1.5 py-0.5 text-[11px] font-semibold text-white shadow-sm transition-transform hover:scale-105 cursor-pointer z-10 flex items-center overflow-hidden whitespace-nowrap`}
-                                        style={{
-                                          width: `calc(${widthPercent}% + ${gapAdjustment}px)`,
-                                          top: `${topPosition}px`,
-                                        }}
-                                        onClick={(
-                                          e: React.MouseEvent<HTMLDivElement>
-                                        ) => {
-                                          e.stopPropagation();
-                                          onEventDoubleClick(evt);
-                                        }}
-                                        title={`${evt.title}\n${new Date(
-                                          evt.startDate
-                                        ).toLocaleDateString()} ~ ${new Date(
-                                          evt.endDate
-                                        ).toLocaleDateString()}`}
-                                      >
-                                        <span className="truncate">
-                                          {isWeekStart
-                                            ? `← ${evt.title}`
-                                            : evt.title}
-                                        </span>
-                                      </div>
-                                    );
-                                  }
-                                )}
-
-                              {visibleSingleDay > 0 && (
-                                <div
-                                  style={{
-                                    marginTop: `${
-                                      totalVisibleMultiDay * 22 + 4
-                                    }px`,
-                                  }}
-                                  className="space-y-0.5"
-                                >
-                                  {singleDayAllDayEvents
-                                    .slice(0, visibleSingleDay)
-                                    .map((evt) => (
-                                      <div
-                                        key={`allday-${evt.id}`}
-                                        data-event-clickable
-                                        className={`${evt.color} cursor-pointer truncate rounded-md px-1.5 py-0.5 text-[11px] font-semibold text-white shadow-sm transition-transform hover:scale-105`}
-                                        onClick={(
-                                          e: React.MouseEvent<HTMLDivElement>
-                                        ) => {
-                                          e.stopPropagation();
-                                          onEventDoubleClick(evt);
-                                        }}
-                                        title={`${evt.title} (종일)`}
-                                      >
-                                        {evt.title}
-                                      </div>
-                                    ))}
-                                </div>
-                              )}
-
-                              {visibleTimed > 0 && (
-                                <div
-                                  className="space-y-0.5"
-                                  style={{
-                                    marginTop:
-                                      visibleSingleDay > 0
-                                        ? '4px'
-                                        : `${totalVisibleMultiDay * 22 + 4}px`,
-                                  }}
-                                >
-                                  {timedSingles
-                                    .slice(0, visibleTimed)
-                                    .map((evt) => (
-                                      <div
-                                        key={`timed-${evt.id}`}
-                                        data-event-clickable
-                                        className={`cursor-pointer truncate rounded-md px-1.5 py-0.5 text-[11px] font-medium text-foreground bg-muted hover:bg-muted/70 transition-colors`}
-                                        onClick={(
-                                          e: React.MouseEvent<HTMLDivElement>
-                                        ) => {
-                                          e.stopPropagation();
-                                          onEventDoubleClick(evt);
-                                        }}
-                                        title={`${fmtTime(evt.startDate)} ${
-                                          evt.title
-                                        }`}
-                                      >
-                                        <span
-                                          className="mr-1 inline-block h-2 w-2 rounded-full align-middle"
-                                          style={{ background: 'currentColor' }}
-                                        />
-                                        <span className="align-middle text-xs font-semibold text-muted-foreground">
-                                          {fmtTime(evt.startDate)}
-                                        </span>{' '}
-                                        <span className="align-middle">
-                                          {evt.title}
-                                        </span>
-                                      </div>
-                                    ))}
-                                </div>
-                              )}
-
-                              {hiddenCount > 0 && (
-                                <div
+                                {cellDate.getDate()}
+                              </span>
+                              {onCreateNewEvent && (
+                                <button
                                   data-event-clickable
-                                  className="text-[11px] text-muted-foreground px-1.5 cursor-pointer hover:text-foreground hover:bg-accent/50 rounded transition-colors mt-1"
-                                  style={{
-                                    marginTop: `${Math.max(
-                                      totalVisibleMultiDay * 22 + 4,
-                                      36
-                                    )}px`,
-                                  }}
                                   onClick={(e) => {
                                     e.stopPropagation();
-                                    setDayModalDate(cellDate);
-                                    setDayModalEvents(allDayEventsForDate);
-                                    setShowDayModal(true);
+                                    onCreateNewEvent(cellDate);
                                   }}
+                                  className="opacity-0 group-hover:opacity-100 hover:opacity-100 focus:opacity-100 p-0.5 rounded hover:bg-accent transition-opacity"
                                 >
-                                  +{hiddenCount}개 더보기
-                                </div>
+                                  <Plus className="w-3 h-3 text-muted-foreground" />
+                                </button>
                               )}
-                            </>
-                          )}
-                        </div>
-                      );
-                    })}
+                            </div>
+
+                            {isMobile && allDayEventsForDate.length > 0 ? (
+                              <div className="flex flex-wrap gap-0.5 mt-1">
+                                {allDayEventsForDate
+                                  .slice(0, 6)
+                                  .map((evt, idx) => (
+                                    <div
+                                      key={`dot-${evt.id}-${idx}`}
+                                      className={`w-1.5 h-1.5 rounded-full ${evt.color}`}
+                                      title={evt.title}
+                                    />
+                                  ))}
+                                {allDayEventsForDate.length > 6 && (
+                                  <div className="text-[10px] text-muted-foreground ml-1">
+                                    +{allDayEventsForDate.length - 6}
+                                  </div>
+                                )}
+                              </div>
+                            ) : (
+                              <>
+                                {multiDayEventsForCell
+                                  .filter((m) => m.row < MAX_VISIBLE_EVENTS)
+                                  .map(
+                                    ({
+                                      event: evt,
+                                      row,
+                                      span,
+                                      isWeekStart,
+                                    }) => {
+                                      const widthPercent = span * 100;
+                                      const gapAdjustment = (span - 1) * 4;
+                                      const topPosition = 32 + row * 22;
+
+                                      return (
+                                        <div
+                                          key={`multi-${
+                                            evt.id
+                                          }-${cellDate.getTime()}`}
+                                          data-event-clickable
+                                          className={`${
+                                            evt.color
+                                          } absolute left-2 right-[-4px] ${
+                                            isWeekStart
+                                              ? 'rounded-l-none'
+                                              : 'rounded-l-md'
+                                          } rounded-r-md px-1.5 py-0.5 text-[11px] font-semibold text-white shadow-sm transition-transform hover:scale-105 cursor-pointer z-10 flex items-center overflow-hidden whitespace-nowrap`}
+                                          style={{
+                                            width: `calc(${widthPercent}% + ${gapAdjustment}px)`,
+                                            top: `${topPosition}px`,
+                                          }}
+                                          onClick={(
+                                            e: React.MouseEvent<HTMLDivElement>
+                                          ) => {
+                                            e.stopPropagation();
+                                            onEventDoubleClick(evt);
+                                          }}
+                                          title={`${evt.title}\n${new Date(
+                                            evt.startDate
+                                          ).toLocaleDateString()} ~ ${new Date(
+                                            evt.endDate
+                                          ).toLocaleDateString()}`}
+                                        >
+                                          <span className="truncate">
+                                            {isWeekStart
+                                              ? `← ${evt.title}`
+                                              : evt.title}
+                                          </span>
+                                        </div>
+                                      );
+                                    }
+                                  )}
+
+                                {visibleSingleDay > 0 && (
+                                  <div
+                                    style={{
+                                      marginTop: `${
+                                        totalVisibleMultiDay * 22 + 4
+                                      }px`,
+                                    }}
+                                    className="space-y-0.5"
+                                  >
+                                    {singleDayAllDayEvents
+                                      .slice(0, visibleSingleDay)
+                                      .map((evt) => (
+                                        <div
+                                          key={`allday-${evt.id}`}
+                                          data-event-clickable
+                                          className={`${evt.color} cursor-pointer truncate rounded-md px-1.5 py-0.5 text-[11px] font-semibold text-white shadow-sm transition-transform hover:scale-105`}
+                                          onClick={(
+                                            e: React.MouseEvent<HTMLDivElement>
+                                          ) => {
+                                            e.stopPropagation();
+                                            onEventDoubleClick(evt);
+                                          }}
+                                          title={`${evt.title} (종일)`}
+                                        >
+                                          {evt.title}
+                                        </div>
+                                      ))}
+                                  </div>
+                                )}
+
+                                {visibleTimed > 0 && (
+                                  <div
+                                    className="space-y-0.5"
+                                    style={{
+                                      marginTop:
+                                        visibleSingleDay > 0
+                                          ? '4px'
+                                          : `${
+                                              totalVisibleMultiDay * 22 + 4
+                                            }px`,
+                                    }}
+                                  >
+                                    {timedSingles
+                                      .slice(0, visibleTimed)
+                                      .map((evt) => (
+                                        <div
+                                          key={`timed-${evt.id}`}
+                                          data-event-clickable
+                                          className={`cursor-pointer truncate rounded-md px-1.5 py-0.5 text-[11px] font-medium text-foreground bg-muted hover:bg-muted/70 transition-colors`}
+                                          onClick={(
+                                            e: React.MouseEvent<HTMLDivElement>
+                                          ) => {
+                                            e.stopPropagation();
+                                            onEventDoubleClick(evt);
+                                          }}
+                                          title={`${fmtTime(evt.startDate)} ${
+                                            evt.title
+                                          }`}
+                                        >
+                                          <span
+                                            className="mr-1 inline-block h-2 w-2 rounded-full align-middle"
+                                            style={{
+                                              background: 'currentColor',
+                                            }}
+                                          />
+                                          <span className="align-middle text-xs font-semibold text-muted-foreground">
+                                            {fmtTime(evt.startDate)}
+                                          </span>{' '}
+                                          <span className="align-middle">
+                                            {evt.title}
+                                          </span>
+                                        </div>
+                                      ))}
+                                  </div>
+                                )}
+
+                                {hiddenCount > 0 && (
+                                  <div
+                                    data-event-clickable
+                                    className="text-[11px] text-muted-foreground px-1.5 cursor-pointer hover:text-foreground hover:bg-accent/50 rounded transition-colors mt-1"
+                                    style={{
+                                      marginTop: `${Math.max(
+                                        totalVisibleMultiDay * 22 + 4,
+                                        36
+                                      )}px`,
+                                    }}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setDayModalDate(cellDate);
+                                      setDayModalEvents(allDayEventsForDate);
+                                      setShowDayModal(true);
+                                    }}
+                                  >
+                                    +{hiddenCount}개 더보기
+                                  </div>
+                                )}
+                              </>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
           </div>
-        </div>
-      </Card>
-    );
-  };
+        </Card>
+      );
+    },
+    [
+      currentDate,
+      isMobile,
+      getEventsForMonth,
+      isDateInDragRange,
+      handlePointerDown,
+      handlePointerMove,
+      handlePointerUp,
+      onCreateNewEvent,
+      onEventDoubleClick,
+    ]
+  );
 
-  // 바텀시트 및 더보기 모달 UI 업데이트
   return (
-    <div className="flex flex-col h-full relative">
-      <div className="flex items-center justify-between mb-4 flex-shrink-0">
-        <h2 className="text-xl font-bold">
-          {year}년 {month + 1}월
-        </h2>
-        <div className="flex gap-2">
-          <Button variant="outline" size="icon" onClick={prevMonth}>
-            <ChevronLeft className="w-4 h-4" />
-          </Button>
-          <Button variant="outline" size="icon" onClick={nextMonth}>
-            <ChevronRight className="w-4 h-4" />
-          </Button>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-7 text-center text-sm font-medium mb-1 flex-shrink-0">
-        {['일', '월', '화', '수', '목', '금', '토'].map((d, i) => (
-          <div
-            key={d}
-            className={
-              i === 0 ? 'text-red-500' : i === 6 ? 'text-blue-500' : ''
-            }
-          >
-            {d}
-          </div>
-        ))}
-      </div>
-
+    <>
       <div
         ref={containerRef}
-        className="flex-1 overflow-y-auto space-y-4"
+        className={`max-h-[calc(100vh-200px)] overflow-y-auto scrollbar-hide ${
+          dragRange ? 'touch-none select-none' : ''
+        }`}
         onScroll={handleScroll}
       >
         {displayMonths.map((monthDate) => (
@@ -851,22 +1010,40 @@ export function Calendar({
         ))}
       </div>
 
-      {/* 바텀시트 */}
-      {selectedDate && bottomSheetEvents.length > 0 && (
+      {/* 바텀시트 - 모바일 날짜 클릭 시 */}
+      {isMobile && selectedDate && bottomSheetEvents.length > 0 && (
         <div
-          className="fixed inset-0 z-50 bg-black/50"
-          onClick={() => {
-            setSelectedDate(null);
-            setBottomSheetEvents([]);
-            bottomSheetOpenRef.current = false;
+          className="fixed inset-0 bg-black/50 z-50 flex items-end animate-in fade-in duration-200"
+          onPointerDown={(e) => {
+            if (e.target === e.currentTarget) {
+              setSelectedDate(null);
+              setBottomSheetEvents([]);
+              bottomSheetOpenRef.current = false;
+            }
           }}
         >
           <div
-            className="absolute bottom-0 left-0 right-0 bg-background rounded-t-2xl p-4 max-h-[60vh] overflow-y-auto"
+            className="bg-background rounded-t-3xl w-full flex flex-col shadow-2xl animate-in slide-in-from-bottom duration-300"
+            style={{
+              maxHeight:
+                bottomSheetEvents.length === 1
+                  ? '55vh'
+                  : bottomSheetEvents.length <= 3
+                  ? '70vh'
+                  : '85vh',
+              minHeight:
+                bottomSheetEvents.length === 1
+                  ? '350px'
+                  : bottomSheetEvents.length <= 3
+                  ? '550px'
+                  : '75vh',
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 border-b flex-shrink-0">
+              <h3 className="text-lg font-bold">
                 {selectedDate.getMonth() + 1}월 {selectedDate.getDate()}일
               </h3>
               <Button
@@ -878,41 +1055,61 @@ export function Calendar({
                   bottomSheetOpenRef.current = false;
                 }}
               >
-                <X className="w-4 h-4" />
+                <X className="h-5 w-5" />
               </Button>
             </div>
-            <div className="space-y-2">
-              {bottomSheetEvents.map((evt) => (
-                <div
-                  key={evt.id}
-                  className={`${evt.color} p-3 rounded-lg text-white cursor-pointer`}
-                  onClick={() => {
-                    onEventDoubleClick(evt);
-                    setSelectedDate(null);
-                    setBottomSheetEvents([]);
-                    bottomSheetOpenRef.current = false;
-                  }}
-                >
-                  <div className="font-semibold">{evt.title}</div>
-                  <div className="text-sm opacity-90">
-                    {evt.allDay
-                      ? isMultiDayEvent(evt)
-                        ? `${new Date(
+
+            <div className="flex-1 overflow-y-auto p-4 space-y-3 overscroll-contain">
+              {bottomSheetEvents.length === 0 ? (
+                <p className="text-muted-foreground text-center py-8">
+                  일정이 없습니다
+                </p>
+              ) : (
+                bottomSheetEvents.map((evt) => (
+                  <div
+                    key={evt.id}
+                    className={`${evt.color} rounded-xl p-5 text-white cursor-pointer transition-transform active:scale-[0.98] shadow-lg`}
+                    onClick={() => {
+                      setSelectedDate(null);
+                      setBottomSheetEvents([]);
+                      bottomSheetOpenRef.current = false;
+                      onEventDoubleClick(evt);
+                    }}
+                  >
+                    <div className="font-semibold text-xl mb-2">
+                      {evt.title}
+                    </div>
+                    <div className="text-base opacity-90 font-medium">
+                      {evt.allDay ? (
+                        isMultiDayEvent(evt) ? (
+                          `${new Date(
                             evt.startDate
                           ).toLocaleDateString()} ~ ${new Date(
                             evt.endDate
                           ).toLocaleDateString()}`
-                        : '종일'
-                      : `${fmtTime(evt.startDate)} - ${fmtTime(evt.endDate)}`}
+                        ) : (
+                          '종일'
+                        )
+                      ) : (
+                        <>
+                          {fmtTime(evt.startDate)} - {fmtTime(evt.endDate)}
+                        </>
+                      )}
+                    </div>
+                    {evt.description && (
+                      <div className="text-sm opacity-85 mt-2 leading-relaxed">
+                        {evt.description}
+                      </div>
+                    )}
                   </div>
-                </div>
-              ))}
+                ))
+              )}
             </div>
           </div>
         </div>
       )}
 
-      {/* 더보기 모달 */}
+      {/* 더보기 모달 - PC에서 +N개 더보기 클릭 시 */}
       {showDayModal && dayModalDate && (
         <div
           className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4"
@@ -962,7 +1159,7 @@ export function Calendar({
           </div>
         </div>
       )}
-    </div>
+    </>
   );
 }
 

--- a/components/meeting-calendar.tsx
+++ b/components/meeting-calendar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { format, isToday, addMonths, subMonths } from 'date-fns';
+import { format, isToday, addMonths, subMonths, subDays } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import { ChevronLeft, ChevronRight, Lock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -21,7 +21,7 @@ import type {
 import { toast } from '@/hooks/use-toast';
 import { buildMonthGrid } from '@/lib/helpers';
 
-// 헬퍼 함수: time 문자열 ("HH:00")을 슬롯 번호(0~23)로 변환
+// 헬퍼 함수: time 문자열 ("HH:00")을 슬롯 번호(0~23)로 변환 (현재는 미사용이지만 남겨둠)
 const getSlotNumberFromTime = (time: string): number => {
   const [hour] = time.split(':').map(Number);
   return hour;
@@ -33,6 +33,34 @@ interface MeetingCalendarProps {
   currentUserId?: string;
   readonly?: boolean;
 }
+
+// KST(+9) 기준으로 UTC 날짜가 바뀌는 경계 (0~8 / 9~23 구분)
+const TIMEZONE_OFFSET_HOURS = 9;
+
+/**
+ * 선택된 슬롯(slots)을 기준으로,
+ * - 슬롯 전체가 0~8이거나, 9~23에만 있으면 → 1개의 payload
+ * - 0~8, 9~23을 모두 포함하면 → 전날/당일 기준으로 2개의 payload
+ *   (슬롯 인덱스는 그대로, 날짜만 분리)
+ */
+// 항상 선택한 날짜에 대해 하나의 payload만 생성
+const buildPatchPayloadForSlots = (
+  selectedDate: Date,
+  slots: number[],
+  status: 'POSSIBLE' | 'IMPOSSIBLE'
+): AvailabilitySlotUpdatePayload[] => {
+  if (slots.length === 0) return [];
+
+  const dateStr = format(selectedDate, 'yyyy-MM-dd');
+
+  return [
+    {
+      date: dateStr,
+      slots: Array.from(new Set(slots)).sort((a, b) => a - b),
+      status,
+    },
+  ];
+};
 
 export function MeetingCalendar({
   meeting,
@@ -55,7 +83,6 @@ export function MeetingCalendar({
 
   const [slots, setSlots] = useState<TimeSlotAvailability[]>([]);
 
-  const [isSelecting, setIsSelecting] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStartIdx, setDragStartIdx] = useState<number | null>(null);
   const [dragEndIdx, setDragEndIdx] = useState<number | null>(null);
@@ -64,33 +91,6 @@ export function MeetingCalendar({
   >(null);
 
   const scrollRef = useRef<HTMLDivElement>(null);
-
-  const stateRef = useRef({
-    isDragging,
-    dragStartIdx,
-    dragEndIdx,
-    dragTargetStatus,
-    selectedDate,
-    participantTimeStatuses,
-  });
-
-  useEffect(() => {
-    stateRef.current = {
-      isDragging,
-      dragStartIdx,
-      dragEndIdx,
-      dragTargetStatus,
-      selectedDate,
-      participantTimeStatuses,
-    };
-  }, [
-    isDragging,
-    dragStartIdx,
-    dragEndIdx,
-    dragTargetStatus,
-    selectedDate,
-    participantTimeStatuses,
-  ]);
 
   const currentParticipant = meeting.participants?.find(
     (p) => p.userId === currentUserId
@@ -108,10 +108,6 @@ export function MeetingCalendar({
 
       for (let hour = 0; hour < 24; hour++) {
         const time = `${hour.toString().padStart(2, '0')}:00`;
-        const slotStart = new Date(date);
-        slotStart.setHours(hour, 0, 0, 0);
-        const slotEnd = new Date(date);
-        slotEnd.setHours(hour + 1, 0, 0, 0);
 
         let availableCount = 0;
         let myStatus: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET' = 'UNSET';
@@ -214,35 +210,63 @@ export function MeetingCalendar({
     }
   }, [view]);
 
-  useEffect(() => {
-    const handleGlobalMouseUp = () => {
-      if (isDragging) {
-        handleMouseUp();
-      }
-    };
-    window.addEventListener('mouseup', handleGlobalMouseUp);
-    return () => window.removeEventListener('mouseup', handleGlobalMouseUp);
-  }, [isDragging]);
-
   const getDailyStats = (date: Date) => {
     const dateKey = format(date, 'yyyy-MM-dd');
-    const stat = dailyStats[dateKey];
+    const totalCount =
+      meeting.participants?.length || meeting.invitedUserIds?.length || 0;
 
-    if (!stat) {
+    if (!meeting.participants || meeting.participants.length === 0) {
       return {
         availableCount: 0,
-        totalParticipants:
-          meeting.participants?.length || meeting.invitedUserIds?.length || 0,
+        totalParticipants: totalCount,
         isFullyAvailable: false,
       };
     }
 
+    // 후보 시간대 계산
+    const candidateHours: number[] = [];
+    if (
+      meeting.requirement.isAllDay ||
+      meeting.requirement.timeConstraints.length === 0
+    ) {
+      for (let h = 0; h < 24; h++) candidateHours.push(h);
+    } else {
+      meeting.requirement.timeConstraints.forEach((tc) => {
+        const [startHour] = tc.startTime.split(':').map(Number);
+        const [endHour] = tc.endTime.split(':').map(Number);
+        for (let h = startHour; h < endHour; h++) {
+          if (!candidateHours.includes(h)) candidateHours.push(h);
+        }
+      });
+    }
+
+    let availableCount = 0;
+    meeting.participants.forEach((participant) => {
+      if (participant.status === 'PENDING') {
+        return;
+      }
+
+      const ts = participant.timeStatuses?.find((t) => t.date === dateKey);
+      const impossibleSlots = ts?.impossibleSlots || [];
+
+      const hasAvailableSlot = candidateHours.some(
+        (hour) => !impossibleSlots.includes(hour)
+      );
+
+      if (hasAvailableSlot) {
+        availableCount++;
+      }
+    });
+
+    const pendingCount = meeting.participants.filter(
+      (p) => p.status === 'PENDING'
+    ).length;
+
     return {
-      availableCount: stat.availableParticipants,
-      totalParticipants: stat.totalParticipants,
+      availableCount,
+      totalParticipants: totalCount,
       isFullyAvailable:
-        stat.availableParticipants === stat.totalParticipants &&
-        stat.totalParticipants > 0,
+        availableCount === totalCount && totalCount > 0 && pendingCount === 0,
     };
   };
 
@@ -258,6 +282,7 @@ export function MeetingCalendar({
   const handleBackToMonth = () => {
     setView('month');
     setSelectedDate(null);
+    loadDailyAvailability();
   };
 
   const isDateInRange = (date: Date) => {
@@ -268,82 +293,7 @@ export function MeetingCalendar({
     return date >= start && date <= end;
   };
 
-  const handleSlotToggle = async (
-    time: string,
-    currentStatus: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET'
-  ) => {
-    if (readonly) {
-      toast({
-        title: '수정 불가',
-        description: '현재 모임 상태에서는 일정을 수정할 수 없습니다.',
-        variant: 'destructive',
-      });
-      return;
-    }
-
-    if (!selectedDate || !currentParticipant) return;
-
-    const newStatus: 'POSSIBLE' | 'IMPOSSIBLE' =
-      currentStatus === 'POSSIBLE' ? 'IMPOSSIBLE' : 'POSSIBLE';
-
-    const [hour] = time.split(':').map(Number);
-    const dateStr = format(selectedDate, 'yyyy-MM-dd');
-
-    const payload: AvailabilitySlotUpdatePayload[] = [
-      {
-        date: dateStr,
-        slots: [hour],
-        status: newStatus,
-      },
-    ];
-
-    try {
-      await patchParticipantAvailability(meeting.id, payload);
-
-      const updatedParticipant = { ...currentParticipant };
-      const statusIndex = updatedParticipant.timeStatuses?.findIndex(
-        (ts) => ts.date === dateStr
-      );
-
-      if (statusIndex !== undefined && statusIndex >= 0) {
-        const existingStatus =
-          updatedParticipant.timeStatuses![statusIndex].impossibleSlots || [];
-        if (newStatus === 'IMPOSSIBLE') {
-          updatedParticipant.timeStatuses![statusIndex].impossibleSlots = [
-            ...existingStatus,
-            hour,
-          ];
-        } else {
-          updatedParticipant.timeStatuses![statusIndex].impossibleSlots =
-            existingStatus.filter((s) => s !== hour);
-        }
-      } else {
-        if (!updatedParticipant.timeStatuses)
-          updatedParticipant.timeStatuses = [];
-        updatedParticipant.timeStatuses.push({
-          date: dateStr,
-          impossibleSlots: newStatus === 'IMPOSSIBLE' ? [hour] : [],
-          status: 'IMPOSSIBLE',
-        });
-      }
-
-      setSlots((prevSlots) =>
-        prevSlots.map((s) =>
-          s.time === time ? { ...s, myStatus: newStatus } : s
-        )
-      );
-
-      await loadDailyAvailability();
-    } catch (error) {
-      console.error('Failed to update availability', error);
-      toast({
-        title: '업데이트 실패',
-        description: '일정을 업데이트하지 못했습니다.',
-        variant: 'destructive',
-      });
-    }
-  };
-
+  // 클릭/드래그 공통 시작점: 클릭도 "길이 1짜리 드래그"로 취급
   const handleMouseDown = (
     index: number,
     status: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET'
@@ -385,33 +335,40 @@ export function MeetingCalendar({
     }
 
     const start = Math.min(dragStartIdx, dragEndIdx);
-    const end = Math.max(dragEndIdx, dragStartIdx);
+    const end = Math.max(dragStartIdx, dragEndIdx);
+
+    const currentSlots = generateDailySchedule(selectedDate);
     const selectedSlots: number[] = [];
 
     for (let i = start; i <= end; i++) {
-      if (slots[i]?.isCandidate) {
-        const [hour] = slots[i].time.split(':').map(Number);
+      if (currentSlots[i]?.isCandidate) {
+        const [hour] = currentSlots[i].time.split(':').map(Number);
         selectedSlots.push(hour);
       }
     }
 
     if (selectedSlots.length === 0) {
       setIsDragging(false);
+      setDragStartIdx(null);
+      setDragEndIdx(null);
+      setDragTargetStatus(null);
       return;
     }
 
-    const dateStr = format(selectedDate, 'yyyy-MM-dd');
-    const payload: AvailabilitySlotUpdatePayload[] = [
-      {
-        date: dateStr,
-        slots: selectedSlots,
-        status: dragTargetStatus,
-      },
-    ];
+    // UTC 경계 기준으로 payload 분리
+    const payloads = buildPatchPayloadForSlots(
+      selectedDate,
+      selectedSlots,
+      dragTargetStatus
+    );
 
     try {
-      await patchParticipantAvailability(meeting.id, payload);
+      // 분리된 payload 각각 PATCH
+      for (const payload of payloads) {
+        await patchParticipantAvailability(meeting.id, [payload]);
+      }
 
+      const dateStr = format(selectedDate, 'yyyy-MM-dd');
       const updatedParticipant = { ...currentParticipant };
       const statusIndex = updatedParticipant.timeStatuses?.findIndex(
         (ts) => ts.date === dateStr
@@ -543,7 +500,7 @@ export function MeetingCalendar({
                       onClick={() => isInRange && handleDateClick(date)}
                       disabled={!isInRange}
                       className={cn(
-                        'flex flex-col items-center justify-center rounded-lg text-xs sm:text-sm font-medium transition-all min-h-[40px] sm:min-h-[50px]',
+                        'flex flex-col items-center justify-center rounded-lg text-xs sm:text-sm font-medium transition-all min-h-[52px] sm:min-h-[64px]',
                         isToday(date) && 'ring-2 ring-primary',
                         isInRange
                           ? 'hover:bg-primary/20 cursor-pointer'
@@ -552,11 +509,14 @@ export function MeetingCalendar({
                           ? 'bg-green-100 dark:bg-green-900/30'
                           : stats.availableCount > 0 && isInRange
                           ? 'bg-yellow-100 dark:bg-yellow-900/30'
+                          : isInRange
+                          ? 'bg-gray-300/80 dark:bg-gray-600/80'
                           : ''
                       )}
                     >
                       <span
                         className={cn(
+                          'font-semibold',
                           dayNum === 0
                             ? 'text-red-500'
                             : dayNum === 6
@@ -567,7 +527,7 @@ export function MeetingCalendar({
                         {date.getDate()}
                       </span>
                       {isInRange && (
-                        <span className="text-[10px] text-muted-foreground">
+                        <span className="text-[10px] font-medium text-muted-foreground">
                           {stats.availableCount}/{stats.totalParticipants}
                         </span>
                       )}
@@ -576,6 +536,21 @@ export function MeetingCalendar({
                 })}
               </div>
             ))}
+          </div>
+
+          <div className="mt-3 pt-3 border-t border-border/50 flex flex-wrap gap-3 justify-center text-xs">
+            <div className="flex items-center gap-1.5">
+              <div className="w-4 h-4 rounded bg-green-100 dark:bg-green-900/30 border border-green-500" />
+              <span className="text-muted-foreground">전원 가능</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <div className="w-4 h-4 rounded bg-yellow-100 dark:bg-yellow-900/30 border border-yellow-500" />
+              <span className="text-muted-foreground">일부 가능</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <div className="w-4 h-4 rounded bg-gray-300/80 dark:bg-gray-600/80 border border-gray-500" />
+              <span className="text-muted-foreground">가능 인원 없음</span>
+            </div>
           </div>
         </div>
       </Card>
@@ -619,7 +594,7 @@ export function MeetingCalendar({
           onMouseLeave={handleMouseUp}
         >
           <div className="relative">
-            {/* 시간대 레이블들 - 1시부터 23시까지 */}
+            {/* 시간대 레이블들 - 1시부터 23시까지 (B 스타일 레이아웃) */}
             {Array.from({ length: 23 }).map((_, idx) => {
               const hour = idx + 1;
               return (
@@ -648,7 +623,7 @@ export function MeetingCalendar({
                   dragTargetStatus
                 ) {
                   const start = Math.min(dragStartIdx, dragEndIdx);
-                  const end = Math.max(dragEndIdx, dragStartIdx);
+                  const end = Math.max(dragStartIdx, dragEndIdx);
                   if (index >= start && index <= end && slot.isCandidate) {
                     isAvailable = dragTargetStatus === 'POSSIBLE';
                     isUnavailable = dragTargetStatus === 'IMPOSSIBLE';
@@ -666,6 +641,9 @@ export function MeetingCalendar({
                     : 0;
                 const unavailableRatio = 1 - availableRatio;
 
+                const unavailableCount =
+                  slot.totalParticipants - slot.availableCount;
+
                 return (
                   <div
                     key={index}
@@ -676,11 +654,10 @@ export function MeetingCalendar({
                       }
                     }}
                     onMouseEnter={() => handleMouseEnter(index)}
-                    onClick={() =>
-                      !isDragging &&
-                      slot.isCandidate &&
-                      handleSlotToggle(slot.time, slot.myStatus)
-                    }
+                    // 클릭은 드래그로만 처리하므로, onClick에서는 동작 안 함
+                    onClick={(e) => {
+                      e.preventDefault();
+                    }}
                     className={cn(
                       'h-14 border-t border-border/30 relative flex items-center transition-colors select-none',
                       slot.isCandidate
@@ -692,13 +669,13 @@ export function MeetingCalendar({
                         dragStartIdx !== null &&
                         dragEndIdx !== null &&
                         index >= Math.min(dragStartIdx, dragEndIdx) &&
-                        index <= Math.max(dragEndIdx, dragStartIdx) &&
+                        index <= Math.max(dragStartIdx, dragEndIdx) &&
                         slot.isCandidate
                         ? 'ring-2 ring-primary ring-inset'
                         : ''
                     )}
                   >
-                    {/* 가능 영역 */}
+                    {/* 가능 영역 (B 스타일 바) */}
                     {slot.isCandidate && slot.availableCount > 0 && (
                       <div
                         className="absolute left-0 top-0 bottom-0 bg-teal-50 dark:bg-teal-900/40 transition-all duration-300 flex items-center justify-start px-2 sm:px-3 overflow-hidden"
@@ -721,34 +698,34 @@ export function MeetingCalendar({
                       </div>
                     )}
 
-                    {slot.isCandidate &&
-                      slot.totalParticipants - slot.availableCount > 0 && (
-                        <div
-                          className="absolute top-0 bottom-0 bg-pink-50 dark:bg-pink-900/30 transition-all duration-300 flex items-center justify-start px-2 sm:px-3 overflow-hidden"
-                          style={{
-                            right: 0,
-                            width: `${unavailableRatio * 100}%`,
-                            paddingRight: '80px',
-                          }}
-                        >
-                          <div className="flex flex-col items-start min-w-0">
-                            <span className="text-xs font-bold text-pink-700 dark:text-pink-300 whitespace-nowrap">
-                              {slot.totalParticipants - slot.availableCount}명
-                              불가
-                            </span>
-                            {slotWithParticipants.unavailableParticipants &&
-                              slotWithParticipants.unavailableParticipants
-                                .length > 0 && (
-                                <span className="text-[10px] text-pink-600 dark:text-pink-400 truncate max-w-full">
-                                  {slotWithParticipants.unavailableParticipants.join(
-                                    ', '
-                                  )}
-                                </span>
-                              )}
-                          </div>
+                    {/* 불가능 영역 (B 스타일 바) */}
+                    {slot.isCandidate && unavailableCount > 0 && (
+                      <div
+                        className="absolute top-0 bottom-0 bg-pink-50 dark:bg-pink-900/30 transition-all duration-300 flex items-center justify-start px-2 sm:px-3 overflow-hidden"
+                        style={{
+                          right: 0,
+                          width: `${unavailableRatio * 100}%`,
+                          paddingRight: '80px',
+                        }}
+                      >
+                        <div className="flex flex-col items-start min-w-0">
+                          <span className="text-xs font-bold text-pink-700 dark:text-pink-300 whitespace-nowrap">
+                            {unavailableCount}명 불가
+                          </span>
+                          {slotWithParticipants.unavailableParticipants &&
+                            slotWithParticipants.unavailableParticipants
+                              .length > 0 && (
+                              <span className="text-[10px] text-pink-600 dark:text-pink-400 truncate max-w-full">
+                                {slotWithParticipants.unavailableParticipants.join(
+                                  ', '
+                                )}
+                              </span>
+                            )}
                         </div>
-                      )}
+                      </div>
+                    )}
 
+                    {/* 오른쪽 내 상태 뱃지 */}
                     <div className="absolute right-2 flex items-center gap-2 z-10 pointer-events-none">
                       {isAvailable && (
                         <div className="flex items-center gap-1 text-teal-700 dark:text-teal-300 bg-teal-100/95 dark:bg-teal-900/80 px-2 py-1 rounded-full shadow-sm">

--- a/components/time-range-selector.tsx
+++ b/components/time-range-selector.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type React from 'react';
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 
 interface TimeRangeSelectorProps {
@@ -20,9 +20,19 @@ export function TimeRangeSelector({
   const [dragStartIdx, setDragStartIdx] = useState<number | null>(null);
   const [dragEndIdx, setDragEndIdx] = useState<number | null>(null);
   const [dragTargetSelected, setDragTargetSelected] = useState<boolean>(false);
+  const [isMobile, setIsMobile] = useState(false);
 
   const hours = Array.from({ length: 24 }, (_, i) => i);
   const slotHeight = 48;
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768 || 'ontouchstart' in window);
+    };
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
+    return () => window.removeEventListener('resize', checkMobile);
+  }, []);
 
   const formatHour = (hour: number): string => {
     return `${hour.toString().padStart(2, '0')}:00`;
@@ -30,7 +40,7 @@ export function TimeRangeSelector({
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent, hour: number) => {
-      if (disabled) return;
+      if (disabled || isMobile) return;
       e.preventDefault();
       e.stopPropagation();
 
@@ -40,12 +50,12 @@ export function TimeRangeSelector({
       setDragTargetSelected(!selectedSlots.includes(hour));
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
     },
-    [disabled, selectedSlots]
+    [disabled, selectedSlots, isMobile]
   );
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
-      if (!isDragging || !containerRef.current) return;
+      if (!isDragging || !containerRef.current || isMobile) return;
       e.preventDefault();
 
       const rect = containerRef.current.getBoundingClientRect();
@@ -53,12 +63,17 @@ export function TimeRangeSelector({
       const hour = Math.max(0, Math.min(23, Math.floor(y / slotHeight)));
       setDragEndIdx(hour);
     },
-    [isDragging, slotHeight]
+    [isDragging, slotHeight, isMobile]
   );
 
   const handlePointerUp = useCallback(
     (e: React.PointerEvent) => {
-      if (!isDragging || dragStartIdx === null || dragEndIdx === null) {
+      if (
+        !isDragging ||
+        dragStartIdx === null ||
+        dragEndIdx === null ||
+        isMobile
+      ) {
         setIsDragging(false);
         return;
       }
@@ -89,14 +104,35 @@ export function TimeRangeSelector({
       dragTargetSelected,
       selectedSlots,
       onSlotsChange,
+      isMobile,
     ]
+  );
+
+  const handleSlotClick = useCallback(
+    (hour: number) => {
+      if (disabled) return;
+
+      const newSlots = new Set(selectedSlots);
+      if (newSlots.has(hour)) {
+        newSlots.delete(hour);
+      } else {
+        newSlots.add(hour);
+      }
+      onSlotsChange(Array.from(newSlots).sort((a, b) => a - b));
+    },
+    [disabled, selectedSlots, onSlotsChange]
   );
 
   // 드래그 중 하이라이트 계산
   const getSlotState = (
     hour: number
   ): 'selected' | 'unselected' | 'drag-select' | 'drag-deselect' => {
-    if (isDragging && dragStartIdx !== null && dragEndIdx !== null) {
+    if (
+      isDragging &&
+      dragStartIdx !== null &&
+      dragEndIdx !== null &&
+      !isMobile
+    ) {
       const start = Math.min(dragStartIdx, dragEndIdx);
       const end = Math.max(dragStartIdx, dragEndIdx);
       if (hour >= start && hour <= end) {
@@ -136,6 +172,13 @@ export function TimeRangeSelector({
 
   return (
     <div className="relative w-full">
+      {isMobile && (
+        <div className="mb-2 p-2 bg-blue-50 dark:bg-blue-950/30 rounded-lg">
+          <p className="text-xs text-blue-700 dark:text-blue-300">
+            모바일에서는 각 시간대를 탭하여 선택/해제할 수 있습니다.
+          </p>
+        </div>
+      )}
       <div
         ref={containerRef}
         className={cn(
@@ -185,6 +228,7 @@ export function TimeRangeSelector({
                   height: `${slotHeight}px`,
                 }}
                 onPointerDown={(e) => handlePointerDown(e, hour)}
+                onClick={() => isMobile && handleSlotClick(hour)}
               >
                 {isSelected && (
                   <div className="absolute inset-0 bg-primary/20 flex items-center justify-center">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -11,24 +11,23 @@ import type {
   MeetingStatusUpdateRequest,
 } from '@/types/meeting';
 
-// ✨ FriendDto 정의 (API 파일 내부에 위치)
+// FriendDto
 export type FriendDto = {
   id: string;
   nickname: string;
   profileImageUrl?: string | null;
 };
 
-// ✨ 수정: 슬롯 번호 기반의 새로운 요청 페이로드 타입
+// 슬롯 업데이트 페이로드
 export type AvailabilitySlotUpdatePayload = {
-  date: string; // "YYYY-MM-DD"
-  slots: number[]; // 슬롯 번호 배열 (예: [18, 19, 20])
+  date: string; // ISO 형식 (예: "2025-11-25T00:00:00.000Z")
+  slots: number[];
   status: 'POSSIBLE' | 'IMPOSSIBLE';
 };
 
 export const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
-// ... (fetchAllCalendarEvents, createCalendarEvent 등 기존 함수 생략) ...
 async function apiFetch(input: string, init?: RequestInit) {
   const res = await fetch(`${API_BASE}${input}`, {
     credentials: 'include',
@@ -53,14 +52,10 @@ async function apiFetch(input: string, init?: RequestInit) {
   return res;
 }
 
-/**
- * 전체 기간 일정 조회
- * - BE: GET /api/calendar/events
- */
+/* ===================== Calendar APIs ===================== */
+
 export async function fetchAllCalendarEvents(): Promise<RawCalendarEvent[]> {
-  const res = await apiFetch('/api/calendar/events', {
-    method: 'GET',
-  });
+  const res = await apiFetch('/api/calendar/events', { method: 'GET' });
   return res.json();
 }
 
@@ -68,9 +63,6 @@ export async function fetchCalendarEvents(): Promise<RawCalendarEvent[]> {
   return fetchAllCalendarEvents();
 }
 
-/**
- * 일정 생성
- */
 export async function createCalendarEvent(body: {
   title?: string;
   description?: string;
@@ -86,9 +78,6 @@ export async function createCalendarEvent(body: {
   return res.json();
 }
 
-/**
- * 일정 수정
- */
 export async function updateCalendarEvent(
   id: string,
   body: {
@@ -107,88 +96,50 @@ export async function updateCalendarEvent(
   return res.json();
 }
 
-/**
- * 일정 삭제
- */
 export async function deleteCalendarEvent(id: string): Promise<void> {
-  await apiFetch(`/api/calendar/events/${id}`, {
-    method: 'DELETE',
-  });
+  await apiFetch(`/api/calendar/events/${id}`, { method: 'DELETE' });
 }
 
-// 초대코드 응답 타입
+/* ===================== Friends APIs ===================== */
+
 export type InviteCodeResponse = {
   ownerUserId: string;
   code: string;
 };
 
-/**
- * 내 초대코드 조회
- * GET /api/friends/invite-code
- */
 export async function fetchMyInviteCode(): Promise<InviteCodeResponse> {
-  const res = await apiFetch('/api/friends/invite-code', {
-    method: 'GET',
-  });
+  const res = await apiFetch('/api/friends/invite-code', { method: 'GET' });
   return res.json();
 }
 
-/**
- * 내 친구 목록 조회
- * GET /api/friends
- */
 export async function fetchFriends(): Promise<FriendDto[]> {
-  const res = await apiFetch('/api/friends', {
-    method: 'GET',
-  });
+  const res = await apiFetch('/api/friends', { method: 'GET' });
   return res.json();
 }
 
-/**
- * 초대코드로 친구 추가
- * POST /api/friends/addFriend
- */
 export async function addFriendByCode(code: string): Promise<FriendDto> {
   const res = await fetch(`${API_BASE}/api/friends/addFriend`, {
     method: 'POST',
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ code }),
   });
 
-  if (res.ok) {
-    return res.json(); // FriendDto
-  }
+  if (res.ok) return res.json();
 
-  const message = await res.text();
-
-  if (res.status === 400) {
-    throw new Error(message || '잘못된 요청입니다.');
-  }
-  if (res.status === 404) {
-    throw new Error('친구를 찾을 수 없습니다.');
-  }
-  if (res.status === 409) {
-    throw new Error('이미 친구입니다.');
-  }
-
-  throw new Error(message || '친구 추가 중 알 수 없는 오류가 발생했습니다.');
+  const msg = await res.text();
+  if (res.status === 400) throw new Error(msg || '잘못된 요청입니다.');
+  if (res.status === 404) throw new Error('친구를 찾을 수 없습니다.');
+  if (res.status === 409) throw new Error('이미 친구입니다.');
+  throw new Error(msg || '알 수 없는 오류');
 }
 
 export async function deleteFriend(friendId: string): Promise<void> {
-  await apiFetch(`/api/friends/${friendId}`, {
-    method: 'DELETE',
-  });
+  await apiFetch(`/api/friends/${friendId}`, { method: 'DELETE' });
 }
 
-/* ===== Meeting APIs ===== */
+/* ===================== Meeting APIs ===================== */
 
-/**
- * 모임 생성
- * POST /api/meetings
- */
 export async function createMeeting(
   body: MeetingCreateRequest
 ): Promise<Meeting> {
@@ -199,33 +150,16 @@ export async function createMeeting(
   return res.json();
 }
 
-/**
- * 모임 목록 조회
- * GET /api/meetings
- */
 export async function fetchMeetings(): Promise<Meeting[]> {
-  const res = await apiFetch('/api/meetings', {
-    method: 'GET',
-  });
-  const data = await res.json();
-  return Array.isArray(data) ? data : [];
-}
-
-/**
- * 모임 상세 조회
- * GET /api/meetings/{id}
- */
-export async function fetchMeeting(id: string): Promise<Meeting> {
-  const res = await apiFetch(`/api/meetings/${id}`, {
-    method: 'GET',
-  });
+  const res = await apiFetch('/api/meetings', { method: 'GET' });
   return res.json();
 }
 
-/**
- * 최종 가용 시간 조회
- * GET /api/meetings/{id}/available-slots
- */
+export async function fetchMeeting(id: string): Promise<Meeting> {
+  const res = await apiFetch(`/api/meetings/${id}`, { method: 'GET' });
+  return res.json();
+}
+
 export async function fetchAvailableSlots(
   id: string
 ): Promise<AvailableSlot[]> {
@@ -235,10 +169,6 @@ export async function fetchAvailableSlots(
   return res.json();
 }
 
-/**
- * 날짜별 가용 인원 집계 조회 (월별 캘린더 하이라이트 용)
- * GET /api/meetings/{id}/daily-availability
- */
 export async function fetchDailyAvailability(
   id: string
 ): Promise<Record<string, DailyCountDto>> {
@@ -249,8 +179,7 @@ export async function fetchDailyAvailability(
 }
 
 /**
- * 참여자 응답 업데이트
- * PUT /api/meetings/{id}/status
+ * PUT 전체 업데이트
  */
 export async function updateParticipantStatus(
   id: string,
@@ -264,27 +193,20 @@ export async function updateParticipantStatus(
 }
 
 /**
- * ✨ 수정: 슬롯 번호 기반의 PATCH API 호출
- * PATCH /api/meetings/{meetingId}/status
+ * PATCH 슬롯 부분 업데이트
+ * (프론트 호출부: meetingId, userId, payload)
  */
 export async function patchParticipantAvailability(
   meetingId: string,
-  updates: AvailabilitySlotUpdatePayload[] // ✨ 타입 변경
+  updates: AvailabilitySlotUpdatePayload[]
 ): Promise<Meeting> {
-  // 백엔드 엔드포인트: PATCH /api/meetings/{meetingId}/status
   const res = await apiFetch(`/api/meetings/${meetingId}/status`, {
     method: 'PATCH',
-    // 백엔드는 Instant 범위를 기대하므로, 이 요청을 슬롯 기반으로 변경해야 합니다.
-    // 하지만 현재 백엔드는 슬롯을 기대하도록 수정했으므로, JSON.stringify(updates) 그대로 전송합니다.
     body: JSON.stringify(updates),
   });
   return res.json();
 }
 
-/**
- * 모임 수정 (Host only)
- * PUT /api/meetings/{id}
- */
 export async function updateMeeting(
   id: string,
   body: MeetingUpdateRequest
@@ -296,20 +218,10 @@ export async function updateMeeting(
   return res.json();
 }
 
-/**
- * 모임 삭제 (Host only)
- * DELETE /api/meetings/{id}
- */
 export async function deleteMeeting(id: string): Promise<void> {
-  await apiFetch(`/api/meetings/${id}`, {
-    method: 'DELETE',
-  });
+  await apiFetch(`/api/meetings/${id}`, { method: 'DELETE' });
 }
 
-/**
- * 참여자 설정 수정 (timetable/calendar 반영 여부)
- * PUT /api/meetings/{meetingId}/settings
- */
 export async function updateParticipantSettings(
   meetingId: string,
   body: ParticipantSettingsUpdateRequest
@@ -321,10 +233,6 @@ export async function updateParticipantSettings(
   return res.json();
 }
 
-/**
- * 모임 초대 수락
- * POST /api/meetings/{meetingId}/accept
- */
 export async function acceptMeetingInvitation(
   meetingId: string
 ): Promise<Meeting> {
@@ -335,10 +243,6 @@ export async function acceptMeetingInvitation(
   return res.json();
 }
 
-/**
- * 모임에 사용자 초대
- * POST /api/meetings/{meetingId}/invite
- */
 export async function inviteUserToMeeting(
   meetingId: string,
   email: string
@@ -350,10 +254,6 @@ export async function inviteUserToMeeting(
   return res.json();
 }
 
-/**
- * 모임 상태 변경 (Host only)
- * PATCH /api/meetings/{id}/state
- */
 export async function updateMeetingState(
   id: string,
   body: MeetingStatusUpdateRequest

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
-@import "tw-animate-css";
+/* @import 'tailwindcss';
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -75,8 +75,8 @@
 }
 
 @theme inline {
-  --font-sans: "Geist", "Geist Fallback";
-  --font-mono: "Geist Mono", "Geist Mono Fallback";
+  --font-sans: 'Geist', 'Geist Fallback';
+  --font-mono: 'Geist Mono', 'Geist Mono Fallback';
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -122,4 +122,4 @@
   body {
     @apply bg-background text-foreground;
   }
-}
+} */


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #27 

## 📝 작업 내용
- 모임 월화면 캘린더에서도 초대 안 받은 인원들은 모두 참여 불가능을 기본값
- 모임 24시간 화면에서 참여 불가능한 인원들도 이름 표시
- 모바일 화면에선 시간제약에 드래그 안 먹히게.
- 모바일 화면에서 캘린더 일정있는 날 누르면 바텀시트 잘 안 열림.
- 홈 캘린더에 날짜 드래그 안 되게.
- 모임 캘린더화면 세로 길이 좀 더 키우기
- 모임 캘린더 월화면 색깔 좀 바꾸기
- 홈 캘린더 페이지네이션 → 무한스크롤로 롤백
- 모임 24시간 화면 드래그해서 시간을 설정하면 값이 제대로 안 보내지는 문제
- 모임 월 화면에 갈 때마다 날짜별 가능인원 재계산해서 표시 반영하기(해당 날짜의 후보시간 중 가능한 시간이 하나도 없어야 해당 인원이 해당 날짜에 불가능하다고 계산)
- 모바일 모임 24시간 화면에서 왼쪽 글자가 조금씩 잘리는 문제
등을 수정하였습니다.

> 작업내용 설명

### ✨ 스크린샷

### 💬 리뷰 요구사항
