### PR TITLE
bug : 구글 캘린더 연동 전 prepare-google-link 선행 호출 누락 수정 (#63)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import {
   createCalendarEvent,
   updateCalendarEvent,
   deleteCalendarEvent,
+  prepareGoogleLink,
   API_BASE,
 } from '@/lib/api';
 import { RefreshCw } from 'lucide-react';
@@ -313,7 +314,7 @@ export default function HomePage() {
     }
   };
 
-  const syncNow = () => {
+  const syncNow = async () => {
     const ua = navigator.userAgent;
     const isInApp = /NAVER|KAKAOTALK|Instagram|FB_IAB|FBAN|FBAV|Line\//i.test(ua);
 
@@ -342,6 +343,9 @@ export default function HomePage() {
     }
 
     const base = API_BASE || 'http://localhost:8080';
+    // OAuth 리다이렉트 후 SecurityContext가 Google 사용자로 교체되므로
+    // 세션에 userId를 미리 저장해 두어야 handleGoogleLogin이 userId를 식별할 수 있음
+    await prepareGoogleLink();
     window.location.href = `${base}/oauth2/authorization/google`;
   };
 

--- a/components/onboarding-banner.tsx
+++ b/components/onboarding-banner.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { RefreshCw, X, Calendar } from 'lucide-react';
-import { API_BASE } from '@/lib/api';
+import { API_BASE, prepareGoogleLink } from '@/lib/api';
 
 const STORAGE_KEY = 'onboarding_dismissed';
 
@@ -19,9 +19,12 @@ export function OnboardingBanner() {
     setVisible(false);
   };
 
-  const handleSync = () => {
+  const handleSync = async () => {
     dismiss();
     const base = API_BASE || 'http://localhost:8080';
+    // OAuth 리다이렉트 후 SecurityContext가 Google 사용자로 교체되므로
+    // 세션에 userId를 미리 저장해 두어야 handleGoogleLogin이 userId를 식별할 수 있음
+    await prepareGoogleLink();
     window.location.href = `${base}/oauth2/authorization/google`;
   };
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -57,6 +57,25 @@ async function apiFetch(input: string, init?: RequestInit) {
   return res;
 }
 
+/* ===================== Auth helpers ===================== */
+
+/**
+ * 구글 캘린더 연동 전 호출.
+ * OAuth 리다이렉트 이후 SecurityContext가 Google OAuth2 사용자로 교체되므로
+ * 세션에 현재 userId를 미리 저장해 두어야 handleGoogleLogin이 userId를 식별할 수 있다.
+ */
+export async function prepareGoogleLink(): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/auth/prepare-google-link`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 /* ===================== Calendar APIs ===================== */
 
 export async function fetchAllCalendarEvents(): Promise<RawCalendarEvent[]> {


### PR DESCRIPTION
## Summary

- 구글 캘린더 동기화 버튼 클릭 시 이벤트가 표시되지 않는 버그 수정
- Google OAuth 리다이렉트 전 POST /api/auth/prepare-google-link 를 선행 호출해 세션에 userId를 저장
- lib/api.ts 에 prepareGoogleLink() 헬퍼 추가, syncNow() / handleSync() async 전환

## 원인

OAuth 리다이렉트 흐름에서 Spring Security 필터 실행 순서 문제:
OAuth2AuthorizationRequestRedirectFilter 와 OAuth2LoginAuthenticationFilter 가 chain.doFilter 를 호출하지 않고 처리하므로 JwtAuthFilter가 실행되지 않는다.
그 결과 handleGoogleLogin 실행 시점에 SecurityContextHolder 에 CustomPrincipal 이 없어 userId == null 조건으로 /login redirect 처리되며 동기화가 실행되지 않았음.

## Test plan

- [ ] 카카오 로그인 후 상단 동기화 버튼 클릭 → Google 계정 선택 → 홈으로 돌아왔을 때 캘린더 이벤트 표시 확인
- [ ] 온보딩 배너의 지금 연동하기 클릭 → 동일 흐름 확인
- [ ] BE 로그에서 incremental sync 성공 로그 확인
- [ ] MongoDB calendar_events 컬렉션에 이벤트 저장 확인

Closes #63

Generated with [Claude Code](https://claude.com/claude-code)