### PR TITLE
feat : 카카오 인앱브라우저 인증, 드래그 토글, UX 개선 통합

### DIFF
--- a/app/meetings/[id]/page.tsx
+++ b/app/meetings/[id]/page.tsx
@@ -15,7 +15,7 @@ import { BottomNav } from '@/components/bottom-nav';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { toast } from '@/hooks/use-toast';
 import { useAuth } from '@/context/auth-context';
 import {
@@ -86,6 +86,7 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [showPendingDialog, setShowPendingDialog] = useState(false);
   const [confirmedDate, setConfirmedDate] = useState<Date | undefined>(undefined);
+  const [confirmedDatePickerOpen, setConfirmedDatePickerOpen] = useState(false);
   const [confirmedStartTime, setConfirmedStartTime] = useState('09:00');
   const [confirmedEndTime, setConfirmedEndTime] = useState('10:00');
   const [confirmedAllDay, setConfirmedAllDay] = useState(false);
@@ -475,6 +476,7 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
                         <div key={p.userId} className="flex items-center gap-2">
                           <div className="flex flex-1 items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-green-50 dark:bg-green-900/20 border border-green-200/60 dark:border-green-800/40 min-w-0">
                             <Avatar className="h-5 w-5 flex-shrink-0">
+                              <AvatarImage src={p.profileImageUrl ?? undefined} alt={p.name} />
                               <AvatarFallback className="text-[10px] bg-green-500 text-white">
                                 {p.name?.[0] ?? '?'}
                               </AvatarFallback>
@@ -513,6 +515,7 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
                         <div key={p.userId} className="flex items-center gap-2">
                           <div className="flex flex-1 items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-accent border border-border/40 min-w-0">
                             <Avatar className="h-5 w-5 flex-shrink-0">
+                              <AvatarImage src={p.profileImageUrl ?? undefined} alt={p.name} />
                               <AvatarFallback className="text-[10px] bg-muted-foreground/30 text-muted-foreground">
                                 {p.name?.[0] ?? '?'}
                               </AvatarFallback>
@@ -619,7 +622,7 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
           <div className="space-y-4 py-2">
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-foreground">날짜</label>
-              <Popover>
+              <Popover open={confirmedDatePickerOpen} onOpenChange={setConfirmedDatePickerOpen}>
                 <PopoverTrigger asChild>
                   <button className={cn(
                     'w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-input bg-background text-sm text-left hover:bg-accent transition-colors',
@@ -641,6 +644,15 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
                     toDate={meeting.requirement?.dateRangeEnd ? new Date(meeting.requirement.dateRangeEnd) : undefined}
                     initialFocus
                   />
+                  <div className="border-t border-border p-2">
+                    <Button
+                      size="sm"
+                      className="w-full"
+                      onClick={() => setConfirmedDatePickerOpen(false)}
+                    >
+                      완료
+                    </Button>
+                  </div>
                 </PopoverContent>
               </Popover>
             </div>

--- a/app/meetings/create/page.tsx
+++ b/app/meetings/create/page.tsx
@@ -20,6 +20,7 @@ import { Calendar } from '@/components/ui/calendar';
 import { Switch } from '@/components/ui/switch';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { toast } from '@/hooks/use-toast';
 import { createMeeting, fetchFriends, type FriendDto } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -76,6 +77,7 @@ export default function CreateMeetingPage() {
   const [reflectCalendar, setReflectCalendar] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showTimePicker, setShowTimePicker] = useState(false);
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
 
   useEffect(() => {
     fetchFriends()
@@ -145,7 +147,7 @@ export default function CreateMeetingPage() {
           {/* 날짜 범위 */}
           <div className="space-y-1.5">
             <Label className="text-sm font-medium">후보 날짜 범위</Label>
-            <Popover>
+            <Popover open={datePickerOpen} onOpenChange={setDatePickerOpen}>
               <PopoverTrigger asChild>
                 <Button
                   variant="outline"
@@ -168,6 +170,15 @@ export default function CreateMeetingPage() {
                   initialFocus
                   locale={ko}
                 />
+                <div className="border-t border-border p-2">
+                  <Button
+                    size="sm"
+                    className="w-full"
+                    onClick={() => setDatePickerOpen(false)}
+                  >
+                    완료
+                  </Button>
+                </div>
               </PopoverContent>
             </Popover>
           </div>
@@ -242,9 +253,12 @@ export default function CreateMeetingPage() {
                         checked={selectedFriends.includes(friend.id)}
                         onCheckedChange={() => toggleFriend(friend.id)}
                       />
-                      {friend.profileImageUrl && (
-                        <img src={friend.profileImageUrl} alt={friend.nickname} className="w-7 h-7 rounded-full object-cover" />
-                      )}
+                      <Avatar className="h-7 w-7 flex-shrink-0">
+                        <AvatarImage src={friend.profileImageUrl ?? undefined} alt={friend.nickname} />
+                        <AvatarFallback className="text-[10px] bg-primary/20 text-primary">
+                          {friend.nickname?.[0] ?? '?'}
+                        </AvatarFallback>
+                      </Avatar>
                       <span className="text-sm">{friend.nickname}</span>
                     </div>
                   ))}
@@ -274,7 +288,7 @@ export default function CreateMeetingPage() {
         </main>
 
         {/* 하단 버튼 */}
-        <div className="fixed bottom-0 left-0 right-0 border-t border-border bg-background p-4">
+        <div className="fixed bottom-0 left-0 right-0 border-t border-border bg-background p-4 z-30">
           <Button className="w-full" size="lg" onClick={handleSubmit} disabled={isSubmitting}>
             {isSubmitting ? '생성 중...' : '모임 만들기'}
           </Button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,8 +15,8 @@ import {
   createCalendarEvent,
   updateCalendarEvent,
   deleteCalendarEvent,
-  prepareGoogleLink,
   API_BASE,
+  getAccessToken,
 } from '@/lib/api';
 import { RefreshCw } from 'lucide-react';
 import { mapRawToCalendarEvent } from '@/lib/calendar-utils';
@@ -97,13 +97,17 @@ export default function HomePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trigger]);
 
-  // SSE 부분 패치 — events-changed 이벤트만 여기서 처리 (전체 새로고침은 useSseSync가 담당)
+  // SSE 부분 패치 — events-changed 이벤트만 여기서 처리
   useEffect(() => {
-    const sseUrl = `${API_BASE}/api/sse/events`;
     let es: EventSource;
     let retryTimeout: ReturnType<typeof setTimeout>;
 
     const connect = () => {
+      const accessToken = getAccessToken();
+      const sseUrl = accessToken
+        ? `${API_BASE}/api/sse/events?token=${encodeURIComponent(accessToken)}`
+        : `${API_BASE}/api/sse/events`;
+
       es = new EventSource(sseUrl, { withCredentials: true });
 
       es.addEventListener('events-changed', (e: MessageEvent) => {
@@ -342,10 +346,18 @@ export default function HomePage() {
       return;
     }
 
+    // 구글 OAuth 리다이렉트 전 userId를 세션에 저장 (콜백에서 SecurityContext가 교체되므로)
+    try {
+      await fetch(`${API_BASE}/api/auth/prepare-google-link`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { Authorization: `Bearer ${getAccessToken() ?? ''}` },
+      });
+    } catch (e) {
+      console.error('prepare-google-link failed', e);
+    }
+
     const base = API_BASE || 'http://localhost:8080';
-    // OAuth 리다이렉트 후 SecurityContext가 Google 사용자로 교체되므로
-    // 세션에 userId를 미리 저장해 두어야 handleGoogleLogin이 userId를 식별할 수 있음
-    await prepareGoogleLink();
     window.location.href = `${base}/oauth2/authorization/google`;
   };
 

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -16,9 +16,9 @@ export function BottomNav() {
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-sm border-t border-border/40"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 8px)' }}
     >
-      <div className="flex items-center justify-around">
+      <div className="flex items-center justify-around pt-1">
         {navItems.map((item) => {
           const Icon = item.icon;
           const isActive = pathname === item.href;

--- a/components/meeting-calendar.tsx
+++ b/components/meeting-calendar.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { format, isToday, addMonths, subMonths, subDays } from 'date-fns';
+import { format, isToday, addMonths, subMonths } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { ChevronLeft, ChevronRight, Lock } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Lock, CalendarDays } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import {
   fetchDailyAvailability,
@@ -17,15 +18,10 @@ import type {
   TimeSlotAvailability,
   DailyCountDto,
   ParticipantTimeStatus,
+  MeetingParticipant,
 } from '@/types/meeting';
 import { toast } from '@/hooks/use-toast';
 import { buildMonthGrid } from '@/lib/helpers';
-
-// 헬퍼 함수: time 문자열 ("HH:00")을 슬롯 번호(0~23)로 변환 (현재는 미사용이지만 남겨둠)
-const getSlotNumberFromTime = (time: string): number => {
-  const [hour] = time.split(':').map(Number);
-  return hour;
-};
 
 interface MeetingCalendarProps {
   meeting: Meeting;
@@ -34,32 +30,14 @@ interface MeetingCalendarProps {
   readonly?: boolean;
 }
 
-// KST(+9) 기준으로 UTC 날짜가 바뀌는 경계 (0~8 / 9~23 구분)
-const TIMEZONE_OFFSET_HOURS = 9;
-
-/**
- * 선택된 슬롯(slots)을 기준으로,
- * - 슬롯 전체가 0~8이거나, 9~23에만 있으면 → 1개의 payload
- * - 0~8, 9~23을 모두 포함하면 → 전날/당일 기준으로 2개의 payload
- *   (슬롯 인덱스는 그대로, 날짜만 분리)
- */
-// 항상 선택한 날짜에 대해 하나의 payload만 생성
 const buildPatchPayloadForSlots = (
   selectedDate: Date,
   slots: number[],
   status: 'POSSIBLE' | 'IMPOSSIBLE'
 ): AvailabilitySlotUpdatePayload[] => {
   if (slots.length === 0) return [];
-
   const dateStr = format(selectedDate, 'yyyy-MM-dd');
-
-  return [
-    {
-      date: dateStr,
-      slots: Array.from(new Set(slots)).sort((a, b) => a - b),
-      status,
-    },
-  ];
+  return [{ date: dateStr, slots: Array.from(new Set(slots)).sort((a, b) => a - b), status }];
 };
 
 export function MeetingCalendar({
@@ -70,51 +48,60 @@ export function MeetingCalendar({
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [view, setView] = useState<'month' | 'day'>('month');
-  const [dailyStats, setDailyStats] = useState<Record<string, DailyCountDto>>(
-    {}
-  );
+  const [dailyStats, setDailyStats] = useState<Record<string, DailyCountDto>>({});
 
-  const initialParticipant = meeting.participants?.find(
-    (p) => p.userId === currentUserId
-  );
-  const [participantTimeStatuses, setParticipantTimeStatuses] = useState<
-    ParticipantTimeStatus[]
-  >(initialParticipant?.timeStatuses || []);
+  // 로컬 participant 상태 - PATCH 후 즉각 반영용
+  const [localParticipant, setLocalParticipant] = useState<MeetingParticipant | null>(null);
 
   const [slots, setSlots] = useState<TimeSlotAvailability[]>([]);
 
+  // 일 뷰 드래그
   const [isDragging, setIsDragging] = useState(false);
   const [dragStartIdx, setDragStartIdx] = useState<number | null>(null);
   const [dragEndIdx, setDragEndIdx] = useState<number | null>(null);
-  const [dragTargetStatus, setDragTargetStatus] = useState<
-    'POSSIBLE' | 'IMPOSSIBLE' | null
-  >(null);
+  const [dragTargetStatus, setDragTargetStatus] = useState<'POSSIBLE' | 'IMPOSSIBLE' | null>(null);
+  // 일 뷰 모바일 토글
+  const [dayDragMode, setDayDragMode] = useState(false);
+
+  // 월 뷰 드래그
+  const [monthDragging, setMonthDragging] = useState(false);
+  const [monthDragDates, setMonthDragDates] = useState<Set<string>>(new Set());
+  const [monthDragTarget, setMonthDragTarget] = useState<'POSSIBLE' | 'IMPOSSIBLE'>('POSSIBLE');
+  const monthDragRef = useRef(false);
+  const monthDragStarted = useRef(false);
+  const monthMouseDownDate = useRef<Date | null>(null);
+  // 월 뷰 모바일 토글
+  const [monthDragMode, setMonthDragMode] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const currentParticipant = meeting.participants?.find(
-    (p) => p.userId === currentUserId
-  );
+  const currentParticipant = localParticipant ??
+    meeting.participants?.find((p) => p.userId === currentUserId) ?? null;
+
   const todayStatus = currentParticipant?.timeStatuses?.find(
     (ts) => selectedDate && ts.date === format(selectedDate, 'yyyy-MM-dd')
   );
 
   const totalParticipants = meeting.participants?.length || 0;
 
+  // meeting.participants 변경 시 로컬 상태 동기화
+  useEffect(() => {
+    const p = meeting.participants?.find((p) => p.userId === currentUserId);
+    if (p) setLocalParticipant({ ...p, timeStatuses: [...(p.timeStatuses || [])] });
+  }, [meeting.participants, currentUserId]);
+
   const generateDailySchedule = useCallback(
-    (date: Date): TimeSlotAvailability[] => {
-      const slots: TimeSlotAvailability[] = [];
+    (date: Date, overrideParticipant?: MeetingParticipant | null): TimeSlotAvailability[] => {
+      const result: TimeSlotAvailability[] = [];
       const dateStr = format(date, 'yyyy-MM-dd');
+      const effectiveParticipant = overrideParticipant !== undefined ? overrideParticipant : currentParticipant;
+      const effectiveTodayStatus = effectiveParticipant?.timeStatuses?.find(ts => ts.date === dateStr);
 
       for (let hour = 0; hour < 24; hour++) {
         const time = `${hour.toString().padStart(2, '0')}:00`;
-
         let availableCount = 0;
-        let myStatus: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET' = 'UNSET';
-
         const availableParticipants: string[] = [];
         const unavailableParticipants: string[] = [];
-        const unsetParticipants: string[] = [];
 
         const isCandidate =
           meeting.requirement.isAllDay ||
@@ -127,14 +114,10 @@ export function MeetingCalendar({
 
         if (meeting.participants) {
           meeting.participants.forEach((participant) => {
-            if (participant.status === 'PENDING') {
-              unsetParticipants.push(participant.name);
-              return;
-            }
-
-            const ts = participant.timeStatuses?.find(
-              (t) => t.date === dateStr
-            );
+            if (participant.status === 'PENDING') return;
+            const ts = participant.userId === currentUserId
+              ? effectiveTodayStatus
+              : participant.timeStatuses?.find((t) => t.date === dateStr);
             if (ts && ts.impossibleSlots?.includes(hour)) {
               unavailableParticipants.push(participant.name);
             } else {
@@ -144,92 +127,57 @@ export function MeetingCalendar({
           });
         }
 
-        if (currentParticipant && isCandidate) {
-          if (currentParticipant.status === 'PENDING') {
+        let myStatus: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET' = 'UNSET';
+        if (effectiveParticipant && isCandidate) {
+          if (effectiveParticipant.status === 'PENDING') {
             myStatus = 'UNSET';
-          } else if (
-            todayStatus &&
-            todayStatus.impossibleSlots?.includes(hour)
-          ) {
+          } else if (effectiveTodayStatus && effectiveTodayStatus.impossibleSlots?.includes(hour)) {
             myStatus = 'IMPOSSIBLE';
           } else {
             myStatus = 'POSSIBLE';
           }
         }
 
-        slots.push({
-          time,
-          availableCount,
-          totalParticipants,
-          isCandidate,
-          myStatus,
-          availableParticipants,
-          unavailableParticipants,
-        } as any);
+        result.push({ time, availableCount, totalParticipants, isCandidate, myStatus, availableParticipants, unavailableParticipants } as any);
       }
-
-      return slots;
+      return result;
     },
-    [meeting, currentParticipant, todayStatus, totalParticipants]
+    [meeting, currentParticipant, todayStatus, totalParticipants, currentUserId]
   );
 
   const loadDailyAvailability = useCallback(async () => {
     try {
       const stats = await fetchDailyAvailability(meeting.id);
       setDailyStats(stats);
-    } catch (error) {
-      console.error('Failed to load daily availability', error);
+    } catch {
       toast({ title: '가용 시간 정보를 불러오지 못했습니다.', variant: 'destructive' });
     }
   }, [meeting.id]);
 
   useEffect(() => {
     const initialDate = new Date(meeting.requirement.dateRangeStart);
-    setCurrentMonth(
-      new Date(initialDate.getFullYear(), initialDate.getMonth(), 1)
-    );
+    setCurrentMonth(new Date(initialDate.getFullYear(), initialDate.getMonth(), 1));
     loadDailyAvailability();
-
-    const initialParticipant = meeting.participants?.find(
-      (p) => p.userId === currentUserId
-    );
-    if (initialParticipant) {
-      setParticipantTimeStatuses(initialParticipant.timeStatuses || []);
-    }
-  }, [meeting.id, currentUserId, meeting.participants, loadDailyAvailability]);
+  }, [meeting.id, loadDailyAvailability]);
 
   useEffect(() => {
     if (view === 'day' && scrollRef.current) {
       setTimeout(() => {
-        const scrollContainer = scrollRef.current?.querySelector(
-          '[data-radix-scroll-area-viewport]'
-        );
-        if (scrollContainer) {
-          scrollContainer.scrollTop = 540;
-        }
+        scrollRef.current?.scrollTo({ top: 540 });
       }, 100);
     }
   }, [view]);
 
   const getDailyStats = (date: Date) => {
     const dateKey = format(date, 'yyyy-MM-dd');
-    const totalCount =
-      meeting.participants?.length || meeting.invitedUserIds?.length || 0;
+    const totalCount = meeting.participants?.length || meeting.invitedUserIds?.length || 0;
 
     if (!meeting.participants || meeting.participants.length === 0) {
-      return {
-        availableCount: 0,
-        totalParticipants: totalCount,
-        isFullyAvailable: false,
-      };
+      return { availableCount: 0, totalParticipants: totalCount, isFullyAvailable: false };
     }
 
-    // 후보 시간대 계산
     const candidateHours: number[] = [];
-    if (
-      meeting.requirement.isAllDay ||
-      meeting.requirement.timeConstraints.length === 0
-    ) {
+    if (meeting.requirement.isAllDay || meeting.requirement.timeConstraints.length === 0) {
       for (let h = 0; h < 24; h++) candidateHours.push(h);
     } else {
       meeting.requirement.timeConstraints.forEach((tc) => {
@@ -243,32 +191,30 @@ export function MeetingCalendar({
 
     let availableCount = 0;
     meeting.participants.forEach((participant) => {
-      if (participant.status === 'PENDING') {
-        return;
-      }
-
-      const ts = participant.timeStatuses?.find((t) => t.date === dateKey);
-      const impossibleSlots = ts?.impossibleSlots || [];
-
-      const hasAvailableSlot = candidateHours.some(
-        (hour) => !impossibleSlots.includes(hour)
-      );
-
-      if (hasAvailableSlot) {
+      if (participant.status === 'PENDING') return;
+      const effectiveTs = participant.userId === currentUserId
+        ? localParticipant?.timeStatuses?.find(t => t.date === dateKey)
+        : participant.timeStatuses?.find((t) => t.date === dateKey);
+      const impossibleSlots = effectiveTs?.impossibleSlots || [];
+      if (candidateHours.some((hour) => !impossibleSlots.includes(hour))) {
         availableCount++;
       }
     });
 
-    const pendingCount = meeting.participants.filter(
-      (p) => p.status === 'PENDING'
-    ).length;
-
+    const pendingCount = meeting.participants.filter((p) => p.status === 'PENDING').length;
     return {
       availableCount,
       totalParticipants: totalCount,
-      isFullyAvailable:
-        availableCount === totalCount && totalCount > 0 && pendingCount === 0,
+      isFullyAvailable: availableCount === totalCount && totalCount > 0 && pendingCount === 0,
     };
+  };
+
+  const isDateInRange = (date: Date) => {
+    const start = new Date(meeting.requirement.dateRangeStart);
+    const end = new Date(meeting.requirement.dateRangeEnd);
+    start.setHours(0, 0, 0, 0);
+    end.setHours(23, 59, 59, 999);
+    return date >= start && date <= end;
   };
 
   const handlePrevMonth = () => setCurrentMonth(subMonths(currentMonth, 1));
@@ -283,72 +229,153 @@ export function MeetingCalendar({
   const handleBackToMonth = () => {
     setView('month');
     setSelectedDate(null);
-    loadDailyAvailability();
   };
 
-  const isDateInRange = (date: Date) => {
-    const start = new Date(meeting.requirement.dateRangeStart);
-    const end = new Date(meeting.requirement.dateRangeEnd);
-    start.setHours(0, 0, 0, 0);
-    end.setHours(23, 59, 59, 999);
-    return date >= start && date <= end;
+  // ── 월 뷰: localParticipant 즉각 반영 헬퍼 ──
+  const applyMonthDragLocally = (dates: string[], target: 'POSSIBLE' | 'IMPOSSIBLE', candidateSlotsMap: Record<string, number[]>) => {
+    setLocalParticipant(prev => {
+      if (!prev) return prev;
+      const updated = { ...prev, timeStatuses: [...(prev.timeStatuses || [])] };
+      dates.forEach(dateStr => {
+        const slotList = candidateSlotsMap[dateStr] || [];
+        const idx = updated.timeStatuses.findIndex(ts => ts.date === dateStr);
+        if (idx >= 0) {
+          let existing = [...(updated.timeStatuses[idx].impossibleSlots || [])];
+          if (target === 'IMPOSSIBLE') {
+            existing = Array.from(new Set([...existing, ...slotList]));
+          } else {
+            existing = existing.filter(s => !slotList.includes(s));
+          }
+          updated.timeStatuses[idx] = { ...updated.timeStatuses[idx], impossibleSlots: existing };
+        } else if (target === 'IMPOSSIBLE' && slotList.length > 0) {
+          updated.timeStatuses.push({ date: dateStr, impossibleSlots: slotList, status: 'IMPOSSIBLE' });
+        }
+      });
+      return updated;
+    });
   };
 
-  // 클릭/드래그 공통 시작점: 클릭도 "길이 1짜리 드래그"로 취급
-  const handleMouseDown = (
-    index: number,
-    status: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET'
-  ) => {
-    if (readonly) return;
-
-    setIsDragging(true);
-    setDragStartIdx(index);
-    setDragEndIdx(index);
-
-    const targetStatus: 'POSSIBLE' | 'IMPOSSIBLE' =
-      status === 'POSSIBLE' || status === 'UNSET' ? 'IMPOSSIBLE' : 'POSSIBLE';
-
-    setDragTargetStatus(targetStatus);
-  };
-
-  const handleMouseEnter = (index: number) => {
-    if (isDragging && !readonly) {
-      setDragEndIdx(index);
+  const getMonthCandidateSlots = (): number[] => {
+    const result: number[] = [];
+    if (meeting.requirement.isAllDay || meeting.requirement.timeConstraints.length === 0) {
+      for (let h = 0; h < 24; h++) result.push(h);
+    } else {
+      meeting.requirement.timeConstraints.forEach(tc => {
+        const [startH] = tc.startTime.split(':').map(Number);
+        const [endH] = tc.endTime.split(':').map(Number);
+        for (let h = startH; h < endH; h++) {
+          if (!result.includes(h)) result.push(h);
+        }
+      });
     }
+    return result;
   };
 
-  const handleMouseUp = async () => {
-    if (readonly) {
-      setIsDragging(false);
+  // ── 월 뷰 드래그 핸들러 ──
+  const handleMonthDateMouseDown = (date: Date, isMobile: boolean) => {
+    if (readonly) return;
+    if (isMobile && !monthDragMode) return;
+    monthDragRef.current = true;
+    monthDragStarted.current = false;
+    monthMouseDownDate.current = date;
+
+    const dateStr = format(date, 'yyyy-MM-dd');
+    const ts = localParticipant?.timeStatuses?.find(t => t.date === dateStr);
+    const hasImpossible = ts && ts.impossibleSlots && ts.impossibleSlots.length > 0;
+    const target: 'POSSIBLE' | 'IMPOSSIBLE' = hasImpossible ? 'POSSIBLE' : 'IMPOSSIBLE';
+    setMonthDragTarget(target);
+    setMonthDragDates(new Set([dateStr]));
+  };
+
+  const handleMonthDateMouseEnter = (date: Date) => {
+    if (!monthDragRef.current) return;
+    if (!isDateInRange(date)) return;
+    monthDragStarted.current = true;
+    setMonthDragging(true);
+    const dateStr = format(date, 'yyyy-MM-dd');
+    setMonthDragDates(prev => new Set([...prev, dateStr]));
+  };
+
+  const handleMonthDateMouseUp = async (clickedDate?: Date) => {
+    if (!monthDragRef.current) return;
+
+    const wasDrag = monthDragStarted.current;
+    monthDragRef.current = false;
+    monthDragStarted.current = false;
+    setMonthDragging(false);
+
+    // PC 단순 클릭 → 일 뷰 이동
+    if (!wasDrag && clickedDate && !monthDragMode) {
+      setMonthDragDates(new Set());
+      handleDateClick(clickedDate);
       return;
     }
 
-    if (
-      !isDragging ||
-      dragStartIdx === null ||
-      dragEndIdx === null ||
-      !dragTargetStatus ||
-      !selectedDate ||
-      !currentParticipant
-    ) {
+    const dates = Array.from(monthDragDates);
+    setMonthDragDates(new Set());
+    if (dates.length === 0) return;
+
+    const candidateSlots = getMonthCandidateSlots();
+    if (candidateSlots.length === 0) return;
+
+    const candidateSlotsMap: Record<string, number[]> = {};
+    dates.forEach(d => { candidateSlotsMap[d] = candidateSlots; });
+
+    // 즉각 로컬 반영
+    applyMonthDragLocally(dates, monthDragTarget, candidateSlotsMap);
+
+    try {
+      for (const dateStr of dates) {
+        const payloads = buildPatchPayloadForSlots(
+          new Date(dateStr + 'T12:00:00'),
+          candidateSlots,
+          monthDragTarget
+        );
+        for (const payload of payloads) {
+          await patchParticipantAvailability(meeting.id, [payload]);
+        }
+      }
+      toast({ title: `${dates.length}일 일정이 업데이트되었습니다.` });
+    } catch {
+      const p = meeting.participants?.find(p => p.userId === currentUserId);
+      if (p) setLocalParticipant({ ...p, timeStatuses: [...(p.timeStatuses || [])] });
+      toast({ title: '일정 업데이트에 실패했습니다.', variant: 'destructive' });
+    }
+  };
+
+  // ── 일 뷰 드래그 핸들러 ──
+  const handleMouseDown = (index: number, status: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET') => {
+    if (readonly) return;
+    setIsDragging(true);
+    setDragStartIdx(index);
+    setDragEndIdx(index);
+    setDragTargetStatus(status === 'POSSIBLE' || status === 'UNSET' ? 'IMPOSSIBLE' : 'POSSIBLE');
+  };
+
+  const handleMouseEnter = (index: number) => {
+    if (isDragging && !readonly) setDragEndIdx(index);
+  };
+
+  const handleMouseUp = async () => {
+    if (readonly) { setIsDragging(false); return; }
+    if (!isDragging || dragStartIdx === null || dragEndIdx === null || !dragTargetStatus || !selectedDate || !currentParticipant) {
       setIsDragging(false);
       return;
     }
 
     const start = Math.min(dragStartIdx, dragEndIdx);
     const end = Math.max(dragStartIdx, dragEndIdx);
-
     const currentSlots = generateDailySchedule(selectedDate);
-    const selectedSlots: number[] = [];
+    const selectedSlotNums: number[] = [];
 
     for (let i = start; i <= end; i++) {
       if (currentSlots[i]?.isCandidate) {
         const [hour] = currentSlots[i].time.split(':').map(Number);
-        selectedSlots.push(hour);
+        selectedSlotNums.push(hour);
       }
     }
 
-    if (selectedSlots.length === 0) {
+    if (selectedSlotNums.length === 0) {
       setIsDragging(false);
       setDragStartIdx(null);
       setDragEndIdx(null);
@@ -356,68 +383,41 @@ export function MeetingCalendar({
       return;
     }
 
-    // UTC 경계 기준으로 payload 분리
-    const payloads = buildPatchPayloadForSlots(
-      selectedDate,
-      selectedSlots,
-      dragTargetStatus
-    );
+    const payloads = buildPatchPayloadForSlots(selectedDate, selectedSlotNums, dragTargetStatus);
+
+    // 즉각 로컬 반영
+    const dateStr = format(selectedDate, 'yyyy-MM-dd');
+    setLocalParticipant(prev => {
+      if (!prev) return prev;
+      const updated = { ...prev, timeStatuses: [...(prev.timeStatuses || [])] };
+      const idx = updated.timeStatuses.findIndex(ts => ts.date === dateStr);
+      if (idx >= 0) {
+        let existing = [...(updated.timeStatuses[idx].impossibleSlots || [])];
+        if (dragTargetStatus === 'IMPOSSIBLE') {
+          existing = Array.from(new Set([...existing, ...selectedSlotNums]));
+        } else {
+          existing = existing.filter(s => !selectedSlotNums.includes(s));
+        }
+        updated.timeStatuses[idx] = { ...updated.timeStatuses[idx], impossibleSlots: existing };
+      } else if (dragTargetStatus === 'IMPOSSIBLE') {
+        updated.timeStatuses.push({ date: dateStr, impossibleSlots: selectedSlotNums, status: 'IMPOSSIBLE' });
+      }
+      return updated;
+    });
+
+    setSlots(prev => prev.map((s, idx) => {
+      if (idx >= start && idx <= end && s.isCandidate) return { ...s, myStatus: dragTargetStatus! };
+      return s;
+    }));
 
     try {
-      // 분리된 payload 각각 PATCH
       for (const payload of payloads) {
         await patchParticipantAvailability(meeting.id, [payload]);
       }
-
-      const dateStr = format(selectedDate, 'yyyy-MM-dd');
-      const updatedParticipant = { ...currentParticipant };
-      const statusIndex = updatedParticipant.timeStatuses?.findIndex(
-        (ts) => ts.date === dateStr
-      );
-
-      if (statusIndex !== undefined && statusIndex >= 0) {
-        let existingSlots =
-          updatedParticipant.timeStatuses![statusIndex].impossibleSlots || [];
-        if (dragTargetStatus === 'IMPOSSIBLE') {
-          existingSlots = Array.from(
-            new Set([...existingSlots, ...selectedSlots])
-          );
-        } else {
-          existingSlots = existingSlots.filter(
-            (s) => !selectedSlots.includes(s)
-          );
-        }
-        updatedParticipant.timeStatuses![statusIndex].impossibleSlots =
-          existingSlots;
-      } else {
-        if (!updatedParticipant.timeStatuses)
-          updatedParticipant.timeStatuses = [];
-        updatedParticipant.timeStatuses.push({
-          date: dateStr,
-          impossibleSlots:
-            dragTargetStatus === 'IMPOSSIBLE' ? selectedSlots : [],
-          status: 'IMPOSSIBLE',
-        });
-      }
-
-      setSlots((prevSlots) =>
-        prevSlots.map((s, idx) => {
-          if (idx >= start && idx <= end && s.isCandidate) {
-            return { ...s, myStatus: dragTargetStatus };
-          }
-          return s;
-        })
-      );
-
-      await loadDailyAvailability();
-    } catch (error) {
-      console.error('Failed to batch update availability', error);
+    } catch {
+      const p = meeting.participants?.find(p => p.userId === currentUserId);
+      if (p) setLocalParticipant({ ...p, timeStatuses: [...(p.timeStatuses || [])] });
       toast({ title: '시간 업데이트에 실패했습니다.', variant: 'destructive' });
-      toast({
-        title: '업데이트 실패',
-        description: '일정을 업데이트하지 못했습니다.',
-        variant: 'destructive',
-      });
     } finally {
       setIsDragging(false);
       setDragStartIdx(null);
@@ -426,6 +426,7 @@ export function MeetingCalendar({
     }
   };
 
+  // ── 렌더: 월 뷰 ──
   const renderMonthView = () => {
     const y = currentMonth.getFullYear();
     const m = currentMonth.getMonth();
@@ -436,77 +437,104 @@ export function MeetingCalendar({
         {readonly && (
           <div className="px-3 py-2 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 flex items-center gap-2">
             <Lock className="h-4 w-4 text-amber-600" />
-            <span className="text-sm text-amber-700 dark:text-amber-300">
-              읽기 전용 모드
-            </span>
+            <span className="text-sm text-amber-700 dark:text-amber-300">읽기 전용 모드</span>
           </div>
         )}
+
+        {/* 헤더: 월 네비게이션 + 모바일 전용 토글 */}
         <div className="flex items-center justify-between bg-gradient-to-r from-primary/10 to-primary/5 p-3 shrink-0">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handlePrevMonth}
-            className="hover:bg-primary/10"
-          >
+          <Button variant="ghost" size="icon" onClick={handlePrevMonth} className="hover:bg-primary/10">
             <ChevronLeft className="h-5 w-5" />
           </Button>
           <h2 className="text-lg font-bold text-foreground flex-1 text-center">
             {format(currentMonth, 'yyyy년 M월', { locale: ko })}
           </h2>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleNextMonth}
-            className="hover:bg-primary/10"
-          >
+          {/* 모바일 전용 드래그 모드 토글 */}
+          {!readonly && (
+            <div className="flex items-center gap-1.5 sm:hidden">
+              <CalendarDays className={cn('h-3.5 w-3.5', monthDragMode ? 'text-primary' : 'text-muted-foreground')} />
+              <Switch
+                checked={monthDragMode}
+                onCheckedChange={(v) => { setMonthDragMode(v); setMonthDragDates(new Set()); }}
+              />
+            </div>
+          )}
+          <Button variant="ghost" size="icon" onClick={handleNextMonth} className="hover:bg-primary/10">
             <ChevronRight className="h-5 w-5" />
           </Button>
         </div>
 
+        {/* 모바일 드래그 모드 안내 배너 */}
+        {!readonly && monthDragMode && (
+          <div className="sm:hidden px-3 py-1.5 bg-primary/5 border-b border-primary/20 text-center">
+            <span className="text-[11px] text-primary font-medium">드래그로 여러 날짜 참석 여부를 한 번에 설정</span>
+          </div>
+        )}
+
         <div className="flex-1 p-2 sm:p-3 flex flex-col">
           <div className="mb-2 grid grid-cols-7 gap-1 text-center">
             {['일', '월', '화', '수', '목', '금', '토'].map((day, idx) => (
-              <div
-                key={day}
-                className={cn(
-                  'text-xs sm:text-sm font-bold',
-                  idx === 0
-                    ? 'text-red-500'
-                    : idx === 6
-                    ? 'text-blue-500'
-                    : 'text-muted-foreground'
-                )}
-              >
-                {day}
-              </div>
+              <div key={day} className={cn('text-xs sm:text-sm font-bold',
+                idx === 0 ? 'text-red-500' : idx === 6 ? 'text-blue-500' : 'text-muted-foreground'
+              )}>{day}</div>
             ))}
           </div>
 
-          <div className="flex-1 flex flex-col gap-1">
+          <div
+            className="flex-1 flex flex-col gap-1"
+            onMouseUp={() => { if (monthDragRef.current) handleMonthDateMouseUp(); }}
+            onMouseLeave={() => { if (monthDragRef.current) handleMonthDateMouseUp(); }}
+          >
             {grid.map((week, weekIdx) => (
-              <div
-                key={`week-${weekIdx}`}
-                className="grid grid-cols-7 gap-1 flex-1"
-              >
+              <div key={`week-${weekIdx}`} className="grid grid-cols-7 gap-1 flex-1">
                 {week.map((date, colIdx) => {
-                  if (!date)
-                    return <div key={`empty-${colIdx}`} className="min-h-0" />;
+                  if (!date) return <div key={`empty-${colIdx}`} className="min-h-0" />;
 
                   const isInRange = isDateInRange(date);
                   const dayNum = date.getDay();
                   const stats = getDailyStats(date);
+                  const dateStr = format(date, 'yyyy-MM-dd');
+                  const isDragHighlighted = monthDragging && monthDragDates.has(dateStr) && isInRange;
 
                   return (
                     <button
                       key={date.toISOString()}
-                      onClick={() => isInRange && handleDateClick(date)}
+                      data-date={dateStr}
                       disabled={!isInRange}
+                      onMouseDown={(e) => {
+                        if (!isInRange) return;
+                        e.preventDefault();
+                        handleMonthDateMouseDown(date, false);
+                      }}
+                      onMouseEnter={() => handleMonthDateMouseEnter(date)}
+                      onMouseUp={() => isInRange && handleMonthDateMouseUp(date)}
+                      onTouchStart={(e) => {
+                        if (!isInRange || !monthDragMode) return;
+                        e.preventDefault();
+                        handleMonthDateMouseDown(date, true);
+                      }}
+                      onTouchMove={(e) => {
+                        if (!monthDragMode) return;
+                        e.preventDefault();
+                        const touch = e.touches[0];
+                        const el = document.elementFromPoint(touch.clientX, touch.clientY);
+                        const ds = el?.getAttribute('data-date');
+                        if (ds) handleMonthDateMouseEnter(new Date(ds + 'T12:00:00'));
+                      }}
+                      onTouchEnd={() => handleMonthDateMouseUp()}
                       className={cn(
                         'flex flex-col items-center justify-center rounded-lg text-xs sm:text-sm font-medium transition-all min-h-[52px] sm:min-h-[64px]',
                         isToday(date) && 'ring-2 ring-primary',
                         isInRange
-                          ? 'hover:bg-primary/20 cursor-pointer'
+                          ? monthDragMode
+                            ? 'cursor-crosshair hover:opacity-80 sm:cursor-pointer'
+                            : 'hover:bg-primary/20 cursor-pointer'
                           : 'opacity-40 cursor-not-allowed',
+                        isDragHighlighted
+                          ? monthDragTarget === 'IMPOSSIBLE'
+                            ? 'ring-2 ring-rose-400 ring-inset brightness-90'
+                            : 'ring-2 ring-emerald-400 ring-inset brightness-110'
+                          : '',
                         stats.isFullyAvailable && isInRange
                           ? 'bg-green-100 dark:bg-green-900/30'
                           : stats.availableCount > 0 && isInRange
@@ -516,18 +544,9 @@ export function MeetingCalendar({
                           : ''
                       )}
                     >
-                      <span
-                        className={cn(
-                          'font-semibold',
-                          dayNum === 0
-                            ? 'text-red-500'
-                            : dayNum === 6
-                            ? 'text-blue-500'
-                            : ''
-                        )}
-                      >
-                        {date.getDate()}
-                      </span>
+                      <span className={cn('font-semibold',
+                        dayNum === 0 ? 'text-red-500' : dayNum === 6 ? 'text-blue-500' : ''
+                      )}>{date.getDate()}</span>
                       {isInRange && (
                         <span className="text-[10px] font-medium text-muted-foreground">
                           {stats.availableCount}/{stats.totalParticipants}
@@ -554,33 +573,33 @@ export function MeetingCalendar({
               <span className="text-muted-foreground">가능 인원 없음</span>
             </div>
           </div>
+          {!readonly && (
+            <p className="hidden sm:block mt-2 text-[11px] text-center text-muted-foreground">
+              클릭하면 일 화면으로 이동 · 드래그하면 여러 날짜 참석 여부를 한 번에 설정
+            </p>
+          )}
         </div>
       </Card>
     );
   };
 
+  // ── 렌더: 일 뷰 ──
   const renderDayView = () => {
     if (!selectedDate) return null;
-
     const currentSlots = generateDailySchedule(selectedDate);
 
     return (
-      <Card className="flex flex-col overflow-hidden shadow-lg h-full">
+      <Card className="flex flex-col overflow-hidden shadow-lg h-full relative">
         {readonly && (
           <div className="px-3 py-2 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 flex items-center gap-2">
             <Lock className="h-4 w-4 text-amber-600" />
-            <span className="text-sm text-amber-700 dark:text-amber-300">
-              읽기 전용 모드
-            </span>
+            <span className="text-sm text-amber-700 dark:text-amber-300">읽기 전용 모드</span>
           </div>
         )}
+
+        {/* 헤더 */}
         <div className="flex items-center justify-between bg-gradient-to-r from-primary/10 to-primary/5 p-3 shrink-0">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleBackToMonth}
-            className="hover:bg-primary/10"
-          >
+          <Button variant="ghost" size="icon" onClick={handleBackToMonth} className="hover:bg-primary/10">
             <ChevronLeft className="h-5 w-5" />
           </Button>
           <h2 className="text-lg font-bold text-foreground">
@@ -589,14 +608,14 @@ export function MeetingCalendar({
           <div className="w-10" />
         </div>
 
+        {/* 스크롤 영역 - dayDragMode ON 시 터치 스크롤 차단 */}
         <div
-          className="flex-1 overflow-y-auto relative"
+          className={cn('flex-1 relative', dayDragMode ? 'overflow-hidden touch-none' : 'overflow-y-auto')}
           ref={scrollRef}
           onMouseUp={handleMouseUp}
           onMouseLeave={handleMouseUp}
         >
           <div className="relative">
-            {/* 시간대 레이블들 - 1시부터 23시까지 (B 스타일 레이아웃) */}
             {Array.from({ length: 23 }).map((_, idx) => {
               const hour = idx + 1;
               return (
@@ -612,18 +631,12 @@ export function MeetingCalendar({
               );
             })}
 
-            {/* 시간대 슬롯들 - 24개 모두 표시 (0~23시) */}
             <div className="pl-16 border-l">
               {currentSlots.map((slot, index) => {
                 let isAvailable = slot.myStatus === 'POSSIBLE';
                 let isUnavailable = slot.myStatus === 'IMPOSSIBLE';
 
-                if (
-                  isDragging &&
-                  dragStartIdx !== null &&
-                  dragEndIdx !== null &&
-                  dragTargetStatus
-                ) {
+                if (isDragging && dragStartIdx !== null && dragEndIdx !== null && dragTargetStatus) {
                   const start = Math.min(dragStartIdx, dragEndIdx);
                   const end = Math.max(dragStartIdx, dragEndIdx);
                   if (index >= start && index <= end && slot.isCandidate) {
@@ -636,130 +649,122 @@ export function MeetingCalendar({
                   availableParticipants?: string[];
                   unavailableParticipants?: string[];
                 };
-
-                const availableRatio =
-                  slot.totalParticipants > 0
-                    ? slot.availableCount / slot.totalParticipants
-                    : 0;
+                const availableRatio = slot.totalParticipants > 0 ? slot.availableCount / slot.totalParticipants : 0;
                 const unavailableRatio = 1 - availableRatio;
-
-                const unavailableCount =
-                  slot.totalParticipants - slot.availableCount;
+                const unavailableCount = slot.totalParticipants - slot.availableCount;
 
                 return (
                   <div
                     key={index}
                     onMouseDown={(e) => {
-                      if (slot.isCandidate) {
+                      if (slot.isCandidate && !readonly) {
                         e.preventDefault();
                         handleMouseDown(index, slot.myStatus);
                       }
                     }}
                     onMouseEnter={() => handleMouseEnter(index)}
-                    // 클릭은 드래그로만 처리하므로, onClick에서는 동작 안 함
-                    onClick={(e) => {
+                    onTouchStart={(e) => {
+                      if (!slot.isCandidate || readonly || !dayDragMode) return;
                       e.preventDefault();
+                      handleMouseDown(index, slot.myStatus);
                     }}
+                    onTouchMove={(e) => {
+                      if (!dayDragMode || readonly) return;
+                      e.preventDefault();
+                      if (!scrollRef.current) return;
+                      const touch = e.touches[0];
+                      const containerRect = scrollRef.current.getBoundingClientRect();
+                      const scrollTop = scrollRef.current.scrollTop;
+                      const relativeY = touch.clientY - containerRect.top + scrollTop;
+                      const SLOT_HEIGHT = 56;
+                      const calculatedIdx = Math.floor(relativeY / SLOT_HEIGHT);
+                      const clampedIdx = Math.max(0, Math.min(23, calculatedIdx));
+                      handleMouseEnter(clampedIdx);
+                    }}
+                    onTouchEnd={handleMouseUp}
+                    data-slot-index={index}
                     className={cn(
                       'h-14 border-t border-border/30 relative flex items-center transition-colors select-none',
                       slot.isCandidate
-                        ? readonly
-                          ? 'cursor-not-allowed opacity-50'
-                          : 'cursor-pointer hover:opacity-90'
+                        ? readonly ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:opacity-90'
                         : 'bg-muted/10 cursor-not-allowed opacity-50',
-                      isDragging &&
-                        dragStartIdx !== null &&
-                        dragEndIdx !== null &&
+                      isDragging && dragStartIdx !== null && dragEndIdx !== null &&
                         index >= Math.min(dragStartIdx, dragEndIdx) &&
-                        index <= Math.max(dragStartIdx, dragEndIdx) &&
-                        slot.isCandidate
-                        ? 'ring-2 ring-primary ring-inset'
-                        : ''
+                        index <= Math.max(dragStartIdx, dragEndIdx) && slot.isCandidate
+                        ? 'ring-2 ring-primary ring-inset' : ''
                     )}
                   >
-                    {/* 가능 영역 (B 스타일 바) */}
                     {slot.isCandidate && slot.availableCount > 0 && (
                       <div
                         className="absolute left-0 top-0 bottom-0 bg-teal-50 dark:bg-teal-900/40 transition-all duration-300 flex items-center justify-start px-2 sm:px-3 overflow-hidden"
                         style={{ width: `${availableRatio * 100}%` }}
                       >
                         <div className="flex flex-col min-w-0">
-                          <span className="text-xs font-bold text-teal-700 dark:text-teal-300 whitespace-nowrap">
-                            {slot.availableCount}명 가능
-                          </span>
-                          {slotWithParticipants.availableParticipants &&
-                            slotWithParticipants.availableParticipants.length >
-                              0 && (
-                              <span className="text-[10px] text-teal-600 dark:text-teal-400 truncate max-w-full">
-                                {slotWithParticipants.availableParticipants.join(
-                                  ', '
-                                )}
-                              </span>
-                            )}
+                          <span className="text-xs font-bold text-teal-700 dark:text-teal-300 whitespace-nowrap">{slot.availableCount}명 가능</span>
+                          {slotWithParticipants.availableParticipants && slotWithParticipants.availableParticipants.length > 0 && (
+                            <span className="text-[10px] text-teal-600 dark:text-teal-400 truncate max-w-full">
+                              {slotWithParticipants.availableParticipants.join(', ')}
+                            </span>
+                          )}
                         </div>
                       </div>
                     )}
-
-                    {/* 불가능 영역 (B 스타일 바) */}
                     {slot.isCandidate && unavailableCount > 0 && (
                       <div
                         className="absolute top-0 bottom-0 bg-pink-50 dark:bg-pink-900/30 transition-all duration-300 flex items-center justify-start px-2 sm:px-3 overflow-hidden"
-                        style={{
-                          right: 0,
-                          width: `${unavailableRatio * 100}%`,
-                          paddingRight: '80px',
-                        }}
+                        style={{ right: 0, width: `${unavailableRatio * 100}%`, paddingRight: '80px' }}
                       >
                         <div className="flex flex-col items-start min-w-0">
-                          <span className="text-xs font-bold text-pink-700 dark:text-pink-300 whitespace-nowrap">
-                            {unavailableCount}명 불가
-                          </span>
-                          {slotWithParticipants.unavailableParticipants &&
-                            slotWithParticipants.unavailableParticipants
-                              .length > 0 && (
-                              <span className="text-[10px] text-pink-600 dark:text-pink-400 truncate max-w-full">
-                                {slotWithParticipants.unavailableParticipants.join(
-                                  ', '
-                                )}
-                              </span>
-                            )}
+                          <span className="text-xs font-bold text-pink-700 dark:text-pink-300 whitespace-nowrap">{unavailableCount}명 불가</span>
+                          {slotWithParticipants.unavailableParticipants && slotWithParticipants.unavailableParticipants.length > 0 && (
+                            <span className="text-[10px] text-pink-600 dark:text-pink-400 truncate max-w-full">
+                              {slotWithParticipants.unavailableParticipants.join(', ')}
+                            </span>
+                          )}
                         </div>
                       </div>
                     )}
-
-                    {/* 오른쪽 내 상태 뱃지 */}
                     <div className="absolute right-2 flex items-center gap-2 z-10 pointer-events-none">
                       {isAvailable && (
                         <div className="flex items-center gap-1 text-teal-700 dark:text-teal-300 bg-teal-100/95 dark:bg-teal-900/80 px-2 py-1 rounded-full shadow-sm">
                           <div className="w-2 h-2 rounded-full bg-emerald-500 shrink-0" />
-                          <span className="text-xs font-bold hidden sm:inline">
-                            참여 가능
-                          </span>
+                          <span className="text-xs font-bold hidden sm:inline">참여 가능</span>
                         </div>
                       )}
                       {isUnavailable && (
                         <div className="flex items-center gap-1 text-rose-700 bg-rose-100/95 dark:bg-rose-900/80 px-2 py-1 rounded-full shadow-sm">
                           <div className="w-2 h-2 rounded-full bg-rose-500 shrink-0" />
-                          <span className="text-xs font-bold hidden sm:inline">
-                            참여 불가
-                          </span>
+                          <span className="text-xs font-bold hidden sm:inline">참여 불가</span>
                         </div>
                       )}
                     </div>
-
-                    {/* 왼쪽 세로 표시선 */}
-                    {isAvailable && (
-                      <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-emerald-500 z-10" />
-                    )}
-                    {isUnavailable && (
-                      <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-rose-500 z-10" />
-                    )}
+                    {isAvailable && <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-emerald-500 z-10" />}
+                    {isUnavailable && <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-rose-500 z-10" />}
                   </div>
                 );
               })}
             </div>
           </div>
         </div>
+
+        {/* 모바일 전용 고정 드래그 토글 */}
+        {!readonly && (
+          <div className={cn(
+            'sm:hidden fixed bottom-20 right-4 z-50',
+            'flex items-center gap-2 px-3 py-2 rounded-full shadow-lg border',
+            dayDragMode
+              ? 'bg-primary text-primary-foreground border-primary'
+              : 'bg-background text-foreground border-border'
+          )}>
+            <CalendarDays className="h-3.5 w-3.5 flex-shrink-0" />
+            <span className="text-xs font-medium whitespace-nowrap">다중 선택</span>
+            <Switch
+              checked={dayDragMode}
+              onCheckedChange={setDayDragMode}
+              className="scale-75"
+            />
+          </div>
+        )}
       </Card>
     );
   };

--- a/components/protected-route.tsx
+++ b/components/protected-route.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react"
 import { useRouter, usePathname, useSearchParams } from "next/navigation"
 import { useAuth } from "@/context/auth-context"
 import { Suspense } from "react"
+import { SplashScreen } from "@/components/splash-screen"
 
 interface ProtectedRouteProps {
   children: React.ReactNode
@@ -25,14 +26,7 @@ function ProtectedRouteInner({ children }: ProtectedRouteProps) {
   }, [user, isLoading, router, pathname, searchParams])
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="text-center">
-          <div className="mb-4 inline-block h-8 w-8 animate-spin rounded-full border-4 border-primary border-r-transparent" />
-          <p className="text-foreground">로딩 중...</p>
-        </div>
-      </div>
-    )
+    return <SplashScreen />
   }
 
   if (!user) return null
@@ -42,11 +36,7 @@ function ProtectedRouteInner({ children }: ProtectedRouteProps) {
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   return (
-    <Suspense fallback={
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-primary border-r-transparent" />
-      </div>
-    }>
+    <Suspense fallback={<SplashScreen />}>
       <ProtectedRouteInner>{children}</ProtectedRouteInner>
     </Suspense>
   )

--- a/components/splash-screen.tsx
+++ b/components/splash-screen.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function SplashScreen() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    // 최소 800ms 표시 후 페이드아웃
+    const timer = setTimeout(() => setVisible(false), 800);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div
+      className={`fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-background transition-opacity duration-300 ${
+        visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      }`}
+    >
+      <div className="flex flex-col items-center gap-4">
+        <div className="h-20 w-20 rounded-3xl bg-primary/10 flex items-center justify-center shadow-sm">
+          <span className="text-4xl">📅</span>
+        </div>
+        <div className="text-center space-y-1">
+          <h1 className="text-2xl font-bold text-foreground">맞춰봄</h1>
+          <p className="text-sm text-muted-foreground">일정을 함께 조율해요</p>
+        </div>
+        <div className="mt-4 h-1 w-24 overflow-hidden rounded-full bg-primary/10">
+          <div className="h-full w-full origin-left animate-[loading_0.8s_ease-in-out_forwards] rounded-full bg-primary" />
+        </div>
+      </div>
+      <style jsx>{`
+        @keyframes loading {
+          from { transform: scaleX(0); }
+          to   { transform: scaleX(1); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/components/weekly-schedule.tsx
+++ b/components/weekly-schedule.tsx
@@ -470,8 +470,8 @@ export function WeeklySchedule() {
                         className="absolute left-0.5 right-0.5 rounded-md cursor-pointer overflow-hidden z-10 transition-all hover:brightness-90 active:scale-[0.98]"
                         style={{
                           ...style,
-                          backgroundColor: hexWithAlpha(slot.color, 0.5),
-                          borderLeft: `4px solid ${slot.color}`,
+                          backgroundColor: hexWithAlpha(slot.color, 0.18),
+                          borderLeft: `3px solid ${slot.color}`,
                           minHeight: '20px',
                         }}
                         onClick={(e) => {
@@ -479,18 +479,15 @@ export function WeeklySchedule() {
                           openEditDialog(slot);
                         }}
                       >
-                        <div className="px-1 pt-0.5 h-full flex flex-col">
-                          <p
-                            className="text-[10px] font-bold leading-tight truncate"
-                            style={{ color: slot.color }}
-                          >
+                        <div
+                          className="px-1 pt-0.5 h-full flex flex-col"
+                          style={{ backgroundColor: hexWithAlpha(slot.color, 0.72) }}
+                        >
+                          <p className="text-[10px] font-bold leading-tight truncate text-gray-900">
                             {slot.title}
                           </p>
                           {!isShort && (
-                            <p
-                              className="text-[9px] leading-none mt-0.5 font-medium"
-                              style={{ color: slot.color, opacity: 0.85 }}
-                            >
+                            <p className="text-[9px] leading-none mt-0.5 font-medium text-gray-800/80">
                               {slot.startTime}–{slot.endTime}
                             </p>
                           )}

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -9,7 +9,7 @@ import React, {
   ReactNode,
 } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { API_BASE } from '@/lib/api';
+import { API_BASE, setAccessToken, getAccessToken, exchangeAuthCode } from '@/lib/api';
 import { useSseSync } from '@/hooks/useSseSync';
 
 type User = {
@@ -38,9 +38,18 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const fetchMe = useCallback(async () => {
     try {
+      const headers: Record<string, string> = {};
+      const token = getAccessToken();
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+
       const res = await fetch(`${API_BASE}/api/auth/me`, {
         credentials: 'include',
+        headers,
       });
+
+      // rotate된 새 access token이 응답 헤더에 있으면 메모리에 저장
+      const newToken = res.headers.get('X-New-Access-Token');
+      if (newToken) setAccessToken(newToken);
 
       if (!res.ok) {
         setUser(null);
@@ -68,6 +77,21 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     (async () => {
+      // 로그인 후 BE가 ?code= 파라미터로 리다이렉트하면 access token 교환
+      if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search);
+        const code = params.get('code');
+        if (code) {
+          try {
+            const token = await exchangeAuthCode(code);
+            setAccessToken(token);
+          } catch (e) {
+            console.error('Auth code exchange failed', e);
+          }
+          // URL에서 code 파라미터 제거
+          window.history.replaceState({}, '', window.location.pathname);
+        }
+      }
       await fetchMe();
       setIsLoading(false);
     })();

--- a/hooks/useSseSync.tsx
+++ b/hooks/useSseSync.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useEventRefresh } from '@/hooks/useEventRefresh';
-import { API_BASE } from '@/lib/api';
+import { API_BASE, getAccessToken } from '@/lib/api';
 import { toast } from '@/hooks/use-toast';
 
 /**
@@ -29,7 +29,13 @@ export function useSseSync(enabled: boolean) {
         esRef.current = null;
       }
 
-      const es = new EventSource(`${API_BASE}/api/sse/events`, {
+      // EventSource는 커스텀 헤더 불가 → access token을 쿼리 파라미터로 전달
+      const accessToken = getAccessToken();
+      const sseUrl = accessToken
+        ? `${API_BASE}/api/sse/events?token=${encodeURIComponent(accessToken)}`
+        : `${API_BASE}/api/sse/events`;
+
+      const es = new EventSource(sseUrl, {
         withCredentials: true,
       });
       esRef.current = es;
@@ -84,6 +90,9 @@ export function useSseSync(enabled: boolean) {
         es.close();
         esRef.current = null;
 
+        // enabled가 false로 바뀐 경우(로그아웃 등)엔 재연결하지 않음
+        if (!enabled) return;
+
         const delay = Math.min(
           1000 * Math.pow(2, retryCountRef.current),
           MAX_RETRY_DELAY_MS
@@ -91,7 +100,7 @@ export function useSseSync(enabled: boolean) {
         retryCountRef.current += 1;
 
         retryTimeoutRef.current = setTimeout(() => {
-          connect();
+          if (enabled) connect();
         }, delay);
       };
     }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -27,16 +27,50 @@ export type AvailabilitySlotUpdatePayload = {
 export const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
+// ── Access Token 메모리 저장소 ────────────────────────────────────────────────
+// httpOnly 쿠키 대신 JS 메모리에 보관 (CSRF 완전 차단, 카카오 인앱브라우저 쿠키 격리 우회)
+let _accessToken: string | null = null;
+
+export function setAccessToken(token: string | null) {
+  _accessToken = token;
+}
+
+export function getAccessToken(): string | null {
+  return _accessToken;
+}
+
+// ── 인증 코드 → Access Token 교환 ────────────────────────────────────────────
+export async function exchangeAuthCode(code: string): Promise<string> {
+  const res = await fetch(`${API_BASE}/api/auth/token?code=${code}`, {
+    method: 'POST',
+  });
+  if (!res.ok) throw new Error('AUTH_CODE_EXCHANGE_FAILED');
+  const data = await res.json();
+  return data.accessToken as string;
+}
+
 async function apiFetch(input: string, init?: RequestInit) {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    ...(init?.headers as Record<string, string> || {}),
+  };
+
+  if (_accessToken) {
+    headers['Authorization'] = `Bearer ${_accessToken}`;
+  }
+
   const res = await fetch(`${API_BASE}${input}`, {
     credentials: 'include',
     ...init,
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      ...(init?.headers || {}),
-    },
+    headers,
   });
+
+  // rotate된 새 access token이 응답 헤더에 있으면 메모리 갱신
+  const newToken = res.headers.get('X-New-Access-Token');
+  if (newToken) {
+    _accessToken = newToken;
+  }
 
   if (res.status === 401) {
     throw new Error('UNAUTHORIZED');

--- a/types/meeting.ts
+++ b/types/meeting.ts
@@ -80,6 +80,7 @@ export type ParticipantSettingsUpdateRequest = {
 export type MeetingParticipant = {
   userId: string;
   name: string;
+  profileImageUrl?: string | null;
   status: 'ACCEPTED' | 'PENDING' | 'DECLINED';
   timeStatuses: ParticipantTimeStatus[];
   reflectTimetable: boolean;


### PR DESCRIPTION
## Summary
- 카카오 인앱브라우저에서 모임 링크 접속 시 401 오류 수정 - authCode 교환 방식 FE 적용, SSE/API 요청에 Bearer 토큰 헤더 포함
- 모임 캘린더/시간대에서 모바일 드래그 토글 Switch 복원 (refactor/58 내용 main에 적용)
- 날짜 팝오버 완료 버튼 추가, 시간 레이블 z-index 겹침 수정, SplashScreen 로딩 화면 적용 등 UX 개선

## Changes
- lib/api.ts: access token 메모리 스토어 (setAccessToken/getAccessToken), exchangeAuthCode, apiFetch Bearer 헤더 + X-New-Access-Token 갱신
- context/auth-context.tsx: ?code= 파라미터 감지 후 authCode 교환 및 URL 정리
- hooks/useSseSync.tsx / app/page.tsx: SSE URL에 ?token= 쿼리 파라미터 추가
- components/meeting-calendar.tsx: dayDragMode/monthDragMode 드래그 토글 복원
- app/meetings/create/page.tsx, app/meetings/[id]/page.tsx: 날짜 팝오버 완료 버튼, fixed 버튼 z-30, Avatar 컴포넌트 적용
- components/protected-route.tsx + splash-screen.tsx: 로딩 스피너 -> SplashScreen 교체
- components/weekly-schedule.tsx: 시간표 블록 스타일 개선
- components/bottom-nav.tsx: safe-area-inset-bottom 패딩
- types/meeting.ts: MeetingParticipant.profileImageUrl 필드 추가

## Test plan
- [ ] 카카오톡 인앱브라우저에서 모임 링크 접속 후 로그인 정상 진입 확인
- [ ] 모임 생성 페이지에서 날짜 선택 후 완료 버튼으로 팝오버 닫힘 확인
- [ ] 모임 상세에서 확정 날짜 팝오버 완료 버튼 동작 확인
- [ ] 모바일에서 모임 캘린더 드래그 토글 Switch 표시 및 다중 선택 동작 확인
- [ ] 모바일에서 시간대 편집 시 드래그 토글 표시 및 동작 확인
- [ ] 가능한 시간대 편집 버튼 클릭 후 모임 만들기 버튼 z-index 정상 확인
- [ ] 로딩 시 SplashScreen(맞춰봄 로고) 표시 확인
- [ ] SSE 연결 및 실시간 알림 정상 동작 확인

Closes #65
Closes #66
Closes #67

Generated with Claude Code
