### PR TITLE
feat/fix : 시간 설정 다중 선택 토글 추가 및 초대 링크 code 파라미터 충돌 수정

### DIFF
--- a/components/time-range-selector.tsx
+++ b/components/time-range-selector.tsx
@@ -3,6 +3,7 @@
 import type React from 'react';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { cn } from '@/lib/utils';
+import { Switch } from '@/components/ui/switch';
 
 interface TimeRangeSelectorProps {
   selectedSlots: number[];
@@ -22,7 +23,8 @@ export function TimeRangeSelector({
   const [dragTargetSelected, setDragTargetSelected] = useState<boolean>(false);
   const [isMobile, setIsMobile] = useState(false);
 
-  // 모바일 롱프레스 드래그 모드
+  // 모바일 드래그 토글 (Switch로 즉시 활성화) + 롱프레스 폴백
+  const [dragToggle, setDragToggle] = useState(false);
   const [isMobileDragMode, setIsMobileDragMode] = useState(false);
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
   const touchStartHourRef = useRef<number | null>(null);
@@ -100,13 +102,13 @@ export function TimeRangeSelector({
   // ── 모바일 탭 (단일 선택) ────────────────────────────────────────────
   const handleSlotTap = useCallback(
     (hour: number) => {
-      if (disabled || isMobileDragMode) return;
+      if (disabled || isMobileDragMode || dragToggle) return;
       const newSlots = new Set(selectedSlots);
       if (newSlots.has(hour)) newSlots.delete(hour);
       else newSlots.add(hour);
       onSlotsChange(Array.from(newSlots).sort((a, b) => a - b));
     },
-    [disabled, selectedSlots, onSlotsChange, isMobileDragMode]
+    [disabled, selectedSlots, onSlotsChange, isMobileDragMode, dragToggle]
   );
 
   // ── 모바일 터치 드래그 ────────────────────────────────────────────────
@@ -115,18 +117,26 @@ export function TimeRangeSelector({
       if (disabled || !isMobile) return;
       touchStartHourRef.current = hour;
 
-      // 롱프레스 400ms → 드래그 모드 진입
-      longPressTimerRef.current = setTimeout(() => {
+      if (dragToggle) {
+        // 토글 ON: 즉시 드래그 모드 진입
         setIsMobileDragMode(true);
         setIsDragging(true);
         setDragStartIdx(hour);
         setDragEndIdx(hour);
         setDragTargetSelected(!selectedSlots.includes(hour));
-        // 진동 피드백 (지원 기기)
-        if (navigator.vibrate) navigator.vibrate(30);
-      }, 400);
+      } else {
+        // 토글 OFF: 롱프레스 400ms 후 드래그 모드 진입
+        longPressTimerRef.current = setTimeout(() => {
+          setIsMobileDragMode(true);
+          setIsDragging(true);
+          setDragStartIdx(hour);
+          setDragEndIdx(hour);
+          setDragTargetSelected(!selectedSlots.includes(hour));
+          if (navigator.vibrate) navigator.vibrate(30);
+        }, 400);
+      }
     },
-    [disabled, isMobile, selectedSlots]
+    [disabled, isMobile, dragToggle, selectedSlots]
   );
 
   const handleTouchMove = useCallback(
@@ -159,12 +169,13 @@ export function TimeRangeSelector({
       }
 
       setIsDragging(false);
-      setIsMobileDragMode(false);
+      // 토글 ON이면 드래그 모드 유지 (다음 터치도 즉시 드래그)
+      if (!dragToggle) setIsMobileDragMode(false);
       setDragStartIdx(null);
       setDragEndIdx(null);
       touchStartHourRef.current = null;
     },
-    [isMobileDragMode, isDragging, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange]
+    [isMobileDragMode, isDragging, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange, dragToggle]
   );
 
   const getSlotState = (
@@ -197,18 +208,26 @@ export function TimeRangeSelector({
     return ranges.join(', ');
   };
 
+  const handleDragToggleChange = (checked: boolean) => {
+    setDragToggle(checked);
+    if (!checked) {
+      setIsMobileDragMode(false);
+      setIsDragging(false);
+      setDragStartIdx(null);
+      setDragEndIdx(null);
+    }
+  };
+
   return (
     <div className="relative w-full">
-      {/* 모바일 안내 배너 */}
+      {/* 모바일 다중 선택 토글 (floating pill) */}
       {isMobile && (
-        <div className="mb-3 px-3 py-2.5 bg-primary/5 border border-primary/15 rounded-xl">
-          <p className="text-xs text-foreground/70 leading-relaxed">
-            <span className="font-medium text-foreground/90">탭</span>으로 단일 선택,{' '}
-            <span className="font-medium text-foreground/90">길게 누른 후 드래그</span>로 여러 시간대를 선택할 수 있어요.
-          </p>
-          {isMobileDragMode && (
-            <p className="text-xs text-primary font-medium mt-1">드래그 모드 활성</p>
-          )}
+        <div className="sm:hidden fixed bottom-20 right-4 z-50 flex items-center gap-2 px-3 py-2 rounded-full bg-background shadow-lg border border-border/60">
+          <span className="text-xs text-muted-foreground">다중 선택</span>
+          <Switch
+            checked={dragToggle}
+            onCheckedChange={handleDragToggleChange}
+          />
         </div>
       )}
 

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -78,7 +78,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     (async () => {
       // 로그인 후 BE가 ?code= 파라미터로 리다이렉트하면 access token 교환
-      if (typeof window !== 'undefined') {
+      // BE(JwtLoginSuccessHandler)는 항상 루트(/)에만 ?code=authCode 로 리다이렉트.
+      // 다른 경로의 ?code= 파라미터(모임 초대 코드 등)는 건드리지 않는다.
+      if (typeof window !== 'undefined' && window.location.pathname === '/') {
         const params = new URLSearchParams(window.location.search);
         const code = params.get('code');
         if (code) {


### PR DESCRIPTION
## Summary
- 모임 생성/편집 가능 시간 설정(TimeRangeSelector)에 모바일 다중 선택 Switch 토글 추가 — meeting-calendar와 동일한 floating pill UI
- 모임 초대 링크(/meetings/join?code=ABCDEF) 접속 시 auth-context가 모임 초대 코드를 auth code로 오인 소비하던 버그 수정

## Changes
- `components/time-range-selector.tsx`: 모바일 전용 "다중 선택" Switch 토글 (fixed bottom-20 right-4, sm:hidden). 토글 ON 시 터치 즉시 드래그 모드 진입, OFF 시 기존 롱프레스(400ms) 폴백 유지
- `context/auth-context.tsx`: authCode 교환 로직을 `pathname === '/'`일 때만 실행. BE(JwtLoginSuccessHandler)는 항상 루트(/)에만 ?code= 파라미터를 붙여 리다이렉트하므로, 다른 경로의 code 파라미터(/meetings/join?code= 등)를 건드리지 않음

## Root Cause (Bug #70)
auth-context.tsx가 모든 경로에서 ?code= 파라미터를 감지 -> exchangeAuthCode('ABCDEF') 호출 -> 실패 후 history.replaceState로 URL에서 code 제거 -> JoinPageContent가 모임 초대 코드를 읽지 못함 -> 빈 입력 폼 표시 또는 미로그인 시 코드 없이 /login으로 리다이렉트

## Test plan
- [ ] 모임 생성 페이지 > 가능한 시간 설정에서 모바일 "다중 선택" 토글 표시 확인
- [ ] 토글 ON: 탭 즉시 드래그 시작 (여러 시간대 한 번에 선택 가능)
- [ ] 토글 OFF: 단일 탭 선택 / 롱프레스 후 드래그 가능
- [ ] 모임 편집(settings) 페이지에서도 동일하게 동작 확인
- [ ] 모임 초대 링크(/meetings/join?code=ABCDEF) 클릭 시 자동으로 해당 모임 참여 처리 확인
- [ ] 비로그인 상태에서 초대 링크 클릭 -> 로그인 후 /meetings/join?code=ABCDEF 로 정상 복귀 확인
- [ ] 카카오 로그인 후 루트(/) 리다이렉트 시 ?code= authCode 교환 정상 동작 확인

Closes #69
Closes #70

Generated with Claude Code
