### PR TITLE
fix : 드래그 deselect ref 완성 및 redirect localStorage 교체

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -59,7 +59,7 @@ function LoginPageContent() {
   const kakaoLogin = () => {
     if (!ageChecked) return;
     if (redirect && redirect !== '/') {
-      sessionStorage.setItem('login_redirect', redirect);
+      localStorage.setItem('login_redirect', redirect);
     }
     window.location.href = `${API_BASE}/oauth2/authorization/kakao`;
   };

--- a/components/time-range-selector.tsx
+++ b/components/time-range-selector.tsx
@@ -29,9 +29,12 @@ export function TimeRangeSelector({
   // 롱프레스 폴백용 상태 (토글 OFF일 때 사용)
   const [isMobileDragMode, setIsMobileDragMode] = useState(false);
 
-  // React state 배치 업데이트 타이밍 문제 우회용 ref
-  // (meeting-calendar의 monthDragRef 패턴과 동일)
+  // React state 배치 업데이트 타이밍 문제 우회용 ref (meeting-calendar 패턴)
+  // handleTouchEnd가 빠른 제스처 시 배치 커밋 전에 실행돼 stale state를 읽는 문제 방어
   const isDraggingRef = useRef(false);
+  const dragStartIdxRef = useRef<number | null>(null);
+  const dragEndIdxRef = useRef<number | null>(null);
+  const dragTargetSelectedRef = useRef<boolean>(false);
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -124,21 +127,31 @@ export function TimeRangeSelector({
       if (disabled || !isMobile) return;
 
       if (dragToggle) {
-        // 토글 ON: 즉시 드래그 시작 (ref로 동기 설정)
+        // 토글 ON: 즉시 드래그 시작
+        const willSelect = !selectedSlots.includes(hour);
+        // ref 동기 설정 (handleTouchEnd가 빠른 제스처에도 올바른 값을 읽도록)
         isDraggingRef.current = true;
+        dragStartIdxRef.current = hour;
+        dragEndIdxRef.current = hour;
+        dragTargetSelectedRef.current = willSelect;
+        // state 설정 (렌더링용 시각 피드백)
         setIsDragging(true);
         setDragStartIdx(hour);
         setDragEndIdx(hour);
-        setDragTargetSelected(!selectedSlots.includes(hour));
+        setDragTargetSelected(willSelect);
       } else {
         // 토글 OFF: 롱프레스 400ms 후 드래그 모드 진입
         longPressTimerRef.current = setTimeout(() => {
+          const willSelect = !selectedSlots.includes(hour);
           isDraggingRef.current = true;
+          dragStartIdxRef.current = hour;
+          dragEndIdxRef.current = hour;
+          dragTargetSelectedRef.current = willSelect;
           setIsMobileDragMode(true);
           setIsDragging(true);
           setDragStartIdx(hour);
           setDragEndIdx(hour);
-          setDragTargetSelected(!selectedSlots.includes(hour));
+          setDragTargetSelected(willSelect);
           if (navigator.vibrate) navigator.vibrate(30);
         }, 400);
       }
@@ -148,12 +161,12 @@ export function TimeRangeSelector({
 
   const handleTouchMove = useCallback(
     (e: React.TouchEvent) => {
-      // ref를 체크해 state 타이밍 문제 우회 (meeting-calendar 패턴)
       if (!isDraggingRef.current) return;
       e.preventDefault(); // 드래그 중 페이지 스크롤 차단
       const touch = e.touches[0];
       const hour = getHourFromY(touch.clientY);
-      setDragEndIdx(hour);
+      dragEndIdxRef.current = hour; // ref 동기 업데이트
+      setDragEndIdx(hour);          // state 업데이트 (렌더링용)
     },
     [getHourFromY]
   );
@@ -165,31 +178,38 @@ export function TimeRangeSelector({
         longPressTimerRef.current = null;
       }
 
-      if (isDraggingRef.current && dragStartIdx !== null && dragEndIdx !== null) {
-        const start = Math.min(dragStartIdx, dragEndIdx);
-        const end = Math.max(dragStartIdx, dragEndIdx);
+      // ref 값으로 계산 (state 배치 업데이트 타이밍 문제 완전 우회)
+      if (isDraggingRef.current && dragStartIdxRef.current !== null && dragEndIdxRef.current !== null) {
+        const start = Math.min(dragStartIdxRef.current, dragEndIdxRef.current);
+        const end = Math.max(dragStartIdxRef.current, dragEndIdxRef.current);
         const newSlots = new Set(selectedSlots);
         for (let i = start; i <= end; i++) {
-          if (dragTargetSelected) newSlots.add(i);
+          if (dragTargetSelectedRef.current) newSlots.add(i);
           else newSlots.delete(i);
         }
         onSlotsChange(Array.from(newSlots).sort((a, b) => a - b));
       }
 
       isDraggingRef.current = false;
+      dragStartIdxRef.current = null;
+      dragEndIdxRef.current = null;
+      dragTargetSelectedRef.current = false;
       setIsDragging(false);
       // 토글 ON이면 드래그 모드 유지 (다음 터치도 즉시 드래그)
       if (!dragToggle) setIsMobileDragMode(false);
       setDragStartIdx(null);
       setDragEndIdx(null);
     },
-    [dragToggle, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange]
+    [dragToggle, selectedSlots, onSlotsChange]
   );
 
   const handleDragToggleChange = (checked: boolean) => {
     setDragToggle(checked);
     if (!checked) {
       isDraggingRef.current = false;
+      dragStartIdxRef.current = null;
+      dragEndIdxRef.current = null;
+      dragTargetSelectedRef.current = false;
       setIsMobileDragMode(false);
       setIsDragging(false);
       setDragStartIdx(null);

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -99,16 +99,17 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     })();
   }, [fetchMe]);
 
-  // 로그인 완료 후 sessionStorage에 저장된 redirect 경로로 이동
+  // 로그인 완료 후 localStorage에 저장된 redirect 경로로 이동
   useEffect(() => {
     if (isLoading || !user) return;
     if (typeof window === 'undefined') return;
 
-    const redirectTo = sessionStorage.getItem('login_redirect');
+    const redirectTo = localStorage.getItem('login_redirect');
     if (redirectTo) {
-      sessionStorage.removeItem('login_redirect');
-      // 현재 이미 해당 경로에 있지 않을 때만 이동
-      if (pathname !== redirectTo && pathname === '/') {
+      localStorage.removeItem('login_redirect');
+      // 상대 경로만 허용 (오픈 리다이렉트 방지)
+      const isSafe = redirectTo.startsWith('/') && !redirectTo.startsWith('//');
+      if (isSafe && pathname !== redirectTo && pathname === '/') {
         router.replace(redirectTo);
       }
     }


### PR DESCRIPTION
## Summary
- TimeRangeSelector에서 선택된 슬롯을 드래그해도 해제되지 않던 버그 수정 (ref 완성)
- 카카오 인앱브라우저 OAuth 리다이렉트 중 sessionStorage 초기화로 invite code 유실되던 문제 수정

## Root Cause

### 드래그 deselect 버그 (#75)
handleTouchEnd 클로저가 dragTargetSelected/dragStartIdx/dragEndIdx를 React state로 참조하는데,
빠른 제스처 시 handleTouchStart의 setState 배치가 handleTouchEnd 실행 전에 커밋되지 않아
이전 값(선택 모드, willSelect=true)을 그대로 사용 -> 해제 대신 재선택이 발생.
dragStartIdxRef/dragEndIdxRef/dragTargetSelectedRef를 추가해 handleTouchStart/Move에서 동기 설정,
handleTouchEnd에서 ref 값으로 계산해 state 타이밍 문제를 완전히 우회.

### localStorage 교체 (#76)
카카오 인앱브라우저에서 OAuth (외부 서버 경유) 리다이렉트 중 sessionStorage가 초기화돼
login_redirect 값이 사라짐 -> 로그인 후 초대 링크로 복귀 실패.
localStorage는 same-origin 내에서 영구 유지 -> 리다이렉트를 거쳐도 보존.
읽을 때 startsWith('/') && !startsWith('//') 검증으로 오픈 리다이렉트 방지.

## Changes
- `components/time-range-selector.tsx`: dragStartIdxRef/dragEndIdxRef/dragTargetSelectedRef 추가, handleTouchEnd ref 기반 계산
- `app/login/page.tsx`: sessionStorage -> localStorage
- `context/auth-context.tsx`: localStorage + 상대 경로 안전 검증

## Test plan
- [ ] 선택된 슬롯 여러 개를 드래그 -> 해제되는지 확인
- [ ] 선택 안 된 슬롯 드래그 -> 선택되는지 확인
- [ ] 카카오 인앱브라우저에서 초대링크 -> 로그인 -> 자동 참여 확인
- [ ] 일반 브라우저에서 초대링크 -> 로그인 -> 자동 참여 확인

Closes #75
Closes #76

Generated with Claude Code
