### PR TITLE
fix : 초대링크 401 toast / 인앱브라우저 전역 감지 / 드래그 stale closure 수정 (#78)

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -103,6 +103,7 @@ jobs:
                 ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
 
             cd /home/ubuntu/Deploy
+            docker system prune -f
             docker compose pull fe
             docker compose up -d --no-deps --force-recreate fe
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -36,10 +36,8 @@ jobs:
         run: |
           if [ "${{ github.ref_name }}" = "main" ]; then
             echo "api_base=https://matuabom.store" >> $GITHUB_OUTPUT
-            echo "is_prod=true" >> $GITHUB_OUTPUT
           else
             echo "api_base=https://dev.matuabom.store" >> $GITHUB_OUTPUT
-            echo "is_prod=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push image
@@ -86,7 +84,6 @@ jobs:
         run: echo "ipv4=$(curl -s https://api.ipify.org)" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Security Group Allow
-        if: github.ref_name == 'main'
         run: |
           aws ec2 authorize-security-group-ingress \
             --group-id ${{ secrets.AWS_SG_ID }} \
@@ -95,7 +92,6 @@ jobs:
             --cidr ${{ steps.ip.outputs.ipv4 }}/32
 
       - name: Deploy to EC2
-        if: github.ref_name == 'main'
         uses: appleboy/ssh-action@v1.0.3
         with:
           host:     ${{ secrets.DEPLOY_HOST }}
@@ -133,7 +129,7 @@ jobs:
             docker image prune -f
 
       - name: Configure AWS Security Group Revoke
-        if: always()
+        if: always() && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress \
             --group-id ${{ secrets.AWS_SG_ID }} \

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/context/auth-context';
 import { EventRefreshProvider } from '@/hooks/useEventRefresh';
 import { Toaster } from '@/components/ui/toaster';
 import { ErrorBoundary } from '@/components/error-boundary';
+import { InAppBrowserGuard } from '@/components/inapp-browser-guard';
 import './globals.css';
 
 const _geist = Geist({ subsets: ['latin'] });
@@ -72,6 +73,7 @@ export default function RootLayout({
           <ErrorBoundary>
             <AuthProvider>
               <EventRefreshProvider>
+                <InAppBrowserGuard />
                 {children}
                 <Toaster />
               </EventRefreshProvider>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -59,7 +59,7 @@ function LoginPageContent() {
   const kakaoLogin = () => {
     if (!ageChecked) return;
     if (redirect && redirect !== '/') {
-      sessionStorage.setItem('login_redirect', redirect);
+      localStorage.setItem('login_redirect', redirect);
     }
     window.location.href = `${API_BASE}/oauth2/authorization/kakao`;
   };

--- a/app/meetings/[id]/page.tsx
+++ b/app/meetings/[id]/page.tsx
@@ -15,7 +15,7 @@ import { BottomNav } from '@/components/bottom-nav';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { toast } from '@/hooks/use-toast';
 import { useAuth } from '@/context/auth-context';
 import {
@@ -86,6 +86,7 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [showPendingDialog, setShowPendingDialog] = useState(false);
   const [confirmedDate, setConfirmedDate] = useState<Date | undefined>(undefined);
+  const [confirmedDatePickerOpen, setConfirmedDatePickerOpen] = useState(false);
   const [confirmedStartTime, setConfirmedStartTime] = useState('09:00');
   const [confirmedEndTime, setConfirmedEndTime] = useState('10:00');
   const [confirmedAllDay, setConfirmedAllDay] = useState(false);
@@ -475,6 +476,7 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
                         <div key={p.userId} className="flex items-center gap-2">
                           <div className="flex flex-1 items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-green-50 dark:bg-green-900/20 border border-green-200/60 dark:border-green-800/40 min-w-0">
                             <Avatar className="h-5 w-5 flex-shrink-0">
+                              <AvatarImage src={p.profileImageUrl ?? undefined} alt={p.name} />
                               <AvatarFallback className="text-[10px] bg-green-500 text-white">
                                 {p.name?.[0] ?? '?'}
                               </AvatarFallback>
@@ -513,6 +515,7 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
                         <div key={p.userId} className="flex items-center gap-2">
                           <div className="flex flex-1 items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-accent border border-border/40 min-w-0">
                             <Avatar className="h-5 w-5 flex-shrink-0">
+                              <AvatarImage src={p.profileImageUrl ?? undefined} alt={p.name} />
                               <AvatarFallback className="text-[10px] bg-muted-foreground/30 text-muted-foreground">
                                 {p.name?.[0] ?? '?'}
                               </AvatarFallback>
@@ -619,7 +622,7 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
           <div className="space-y-4 py-2">
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-foreground">날짜</label>
-              <Popover>
+              <Popover open={confirmedDatePickerOpen} onOpenChange={setConfirmedDatePickerOpen}>
                 <PopoverTrigger asChild>
                   <button className={cn(
                     'w-full flex items-center gap-2 px-3 py-2 rounded-lg border border-input bg-background text-sm text-left hover:bg-accent transition-colors',
@@ -641,6 +644,15 @@ export default function MeetingDetailPage({ params }: { params: Promise<{ id: st
                     toDate={meeting.requirement?.dateRangeEnd ? new Date(meeting.requirement.dateRangeEnd) : undefined}
                     initialFocus
                   />
+                  <div className="border-t border-border p-2">
+                    <Button
+                      size="sm"
+                      className="w-full"
+                      onClick={() => setConfirmedDatePickerOpen(false)}
+                    >
+                      완료
+                    </Button>
+                  </div>
                 </PopoverContent>
               </Popover>
             </div>

--- a/app/meetings/create/page.tsx
+++ b/app/meetings/create/page.tsx
@@ -20,6 +20,7 @@ import { Calendar } from '@/components/ui/calendar';
 import { Switch } from '@/components/ui/switch';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { toast } from '@/hooks/use-toast';
 import { createMeeting, fetchFriends, type FriendDto } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -76,6 +77,7 @@ export default function CreateMeetingPage() {
   const [reflectCalendar, setReflectCalendar] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showTimePicker, setShowTimePicker] = useState(false);
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
 
   useEffect(() => {
     fetchFriends()
@@ -145,7 +147,7 @@ export default function CreateMeetingPage() {
           {/* 날짜 범위 */}
           <div className="space-y-1.5">
             <Label className="text-sm font-medium">후보 날짜 범위</Label>
-            <Popover>
+            <Popover open={datePickerOpen} onOpenChange={setDatePickerOpen}>
               <PopoverTrigger asChild>
                 <Button
                   variant="outline"
@@ -168,6 +170,15 @@ export default function CreateMeetingPage() {
                   initialFocus
                   locale={ko}
                 />
+                <div className="border-t border-border p-2">
+                  <Button
+                    size="sm"
+                    className="w-full"
+                    onClick={() => setDatePickerOpen(false)}
+                  >
+                    완료
+                  </Button>
+                </div>
               </PopoverContent>
             </Popover>
           </div>
@@ -242,9 +253,12 @@ export default function CreateMeetingPage() {
                         checked={selectedFriends.includes(friend.id)}
                         onCheckedChange={() => toggleFriend(friend.id)}
                       />
-                      {friend.profileImageUrl && (
-                        <img src={friend.profileImageUrl} alt={friend.nickname} className="w-7 h-7 rounded-full object-cover" />
-                      )}
+                      <Avatar className="h-7 w-7 flex-shrink-0">
+                        <AvatarImage src={friend.profileImageUrl ?? undefined} alt={friend.nickname} />
+                        <AvatarFallback className="text-[10px] bg-primary/20 text-primary">
+                          {friend.nickname?.[0] ?? '?'}
+                        </AvatarFallback>
+                      </Avatar>
                       <span className="text-sm">{friend.nickname}</span>
                     </div>
                   ))}
@@ -274,7 +288,7 @@ export default function CreateMeetingPage() {
         </main>
 
         {/* 하단 버튼 */}
-        <div className="fixed bottom-0 left-0 right-0 border-t border-border bg-background p-4">
+        <div className="fixed bottom-0 left-0 right-0 border-t border-border bg-background p-4 z-30">
           <Button className="w-full" size="lg" onClick={handleSubmit} disabled={isSubmitting}>
             {isSubmitting ? '생성 중...' : '모임 만들기'}
           </Button>

--- a/app/meetings/join/page.tsx
+++ b/app/meetings/join/page.tsx
@@ -8,23 +8,25 @@ import { Input } from '@/components/ui/input';
 import { ProtectedRoute } from '@/components/protected-route';
 import { joinMeetingByCode } from '@/lib/api';
 import { toast } from '@/hooks/use-toast';
+import { useAuth } from '@/context/auth-context';
 
 function JoinPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { user, isLoading } = useAuth();
   const [code, setCode] = useState('');
   const [isJoining, setIsJoining] = useState(false);
 
-  // URL에 code 파라미터가 있으면 자동 입력 + 자동 참여 시도
+  // 인증 완료 후에만 자동 참여 시도 (비로그인 상태에서 API 호출 시 401 toast 방지)
   useEffect(() => {
+    if (isLoading || !user) return;
     const urlCode = searchParams.get('code');
     if (urlCode) {
       const upper = urlCode.toUpperCase();
       setCode(upper);
-      // 코드가 URL에 있으면 자동으로 참여 시도
       handleJoinWithCode(upper);
     }
-  }, []); // eslint-disable-line
+  }, [user, isLoading]); // eslint-disable-line
 
   const handleJoinWithCode = async (targetCode: string) => {
     const trimmed = targetCode.trim().toUpperCase();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import {
   createCalendarEvent,
   updateCalendarEvent,
   deleteCalendarEvent,
+  prepareGoogleLink,
   API_BASE,
 } from '@/lib/api';
 import { RefreshCw } from 'lucide-react';
@@ -313,7 +314,7 @@ export default function HomePage() {
     }
   };
 
-  const syncNow = () => {
+  const syncNow = async () => {
     const ua = navigator.userAgent;
     const isInApp = /NAVER|KAKAOTALK|Instagram|FB_IAB|FBAN|FBAV|Line\//i.test(ua);
 
@@ -342,6 +343,9 @@ export default function HomePage() {
     }
 
     const base = API_BASE || 'http://localhost:8080';
+    // OAuth 리다이렉트 후 SecurityContext가 Google 사용자로 교체되므로
+    // 세션에 userId를 미리 저장해 두어야 handleGoogleLogin이 userId를 식별할 수 있음
+    await prepareGoogleLink();
     window.location.href = `${base}/oauth2/authorization/google`;
   };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,8 +15,8 @@ import {
   createCalendarEvent,
   updateCalendarEvent,
   deleteCalendarEvent,
-  prepareGoogleLink,
   API_BASE,
+  getAccessToken,
 } from '@/lib/api';
 import { RefreshCw } from 'lucide-react';
 import { mapRawToCalendarEvent } from '@/lib/calendar-utils';
@@ -97,13 +97,17 @@ export default function HomePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trigger]);
 
-  // SSE 부분 패치 — events-changed 이벤트만 여기서 처리 (전체 새로고침은 useSseSync가 담당)
+  // SSE 부분 패치 — events-changed 이벤트만 여기서 처리
   useEffect(() => {
-    const sseUrl = `${API_BASE}/api/sse/events`;
     let es: EventSource;
     let retryTimeout: ReturnType<typeof setTimeout>;
 
     const connect = () => {
+      const accessToken = getAccessToken();
+      const sseUrl = accessToken
+        ? `${API_BASE}/api/sse/events?token=${encodeURIComponent(accessToken)}`
+        : `${API_BASE}/api/sse/events`;
+
       es = new EventSource(sseUrl, { withCredentials: true });
 
       es.addEventListener('events-changed', (e: MessageEvent) => {
@@ -342,10 +346,18 @@ export default function HomePage() {
       return;
     }
 
+    // 구글 OAuth 리다이렉트 전 userId를 세션에 저장 (콜백에서 SecurityContext가 교체되므로)
+    try {
+      await fetch(`${API_BASE}/api/auth/prepare-google-link`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { Authorization: `Bearer ${getAccessToken() ?? ''}` },
+      });
+    } catch (e) {
+      console.error('prepare-google-link failed', e);
+    }
+
     const base = API_BASE || 'http://localhost:8080';
-    // OAuth 리다이렉트 후 SecurityContext가 Google 사용자로 교체되므로
-    // 세션에 userId를 미리 저장해 두어야 handleGoogleLogin이 userId를 식별할 수 있음
-    await prepareGoogleLink();
     window.location.href = `${base}/oauth2/authorization/google`;
   };
 

--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -16,9 +16,9 @@ export function BottomNav() {
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-sm border-t border-border/40"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 8px)' }}
     >
-      <div className="flex items-center justify-around">
+      <div className="flex items-center justify-around pt-1">
         {navItems.map((item) => {
           const Icon = item.icon;
           const isActive = pathname === item.href;

--- a/components/inapp-browser-guard.tsx
+++ b/components/inapp-browser-guard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname } from 'next/navigation';
+
+function detectInAppBrowser(): { isInApp: boolean; name: string } {
+  if (typeof navigator === 'undefined') return { isInApp: false, name: '' };
+  const ua = navigator.userAgent;
+  if (/KAKAOTALK/i.test(ua)) return { isInApp: true, name: '카카오톡' };
+  if (/NAVER/i.test(ua)) return { isInApp: true, name: '네이버' };
+  if (/Instagram/i.test(ua)) return { isInApp: true, name: '인스타그램' };
+  if (/FB_IAB|FBAN|FBAV/i.test(ua)) return { isInApp: true, name: '페이스북' };
+  if (/Line\//i.test(ua)) return { isInApp: true, name: 'LINE' };
+  return { isInApp: false, name: '' };
+}
+
+export function InAppBrowserGuard() {
+  const pathname = usePathname();
+  const [show, setShow] = useState(false);
+  const [urlCopied, setUrlCopied] = useState(false);
+  const [inAppName, setInAppName] = useState('');
+  const [isIOS, setIsIOS] = useState(false);
+
+  useEffect(() => {
+    // 로그인 페이지는 자체 인앱 배너가 있으므로 스킵
+    if (pathname === '/login') return;
+
+    const info = detectInAppBrowser();
+    if (!info.isInApp) return;
+
+    const ua = navigator.userAgent;
+    const isAndroid = /Android/.test(ua);
+    const isIOSDevice = /iPhone|iPad|iPod/.test(ua);
+    setInAppName(info.name);
+    setIsIOS(isIOSDevice);
+
+    if (isAndroid) {
+      // Android: Intent URI로 Chrome 자동 전환 시도
+      const url = window.location.href;
+      const intentUrl = `intent://${url.replace(/^https?:\/\//, '')}#Intent;scheme=https;package=com.android.chrome;S.browser_fallback_url=${encodeURIComponent(url)};end`;
+      window.location.href = intentUrl;
+      // Intent 전환 실패 시(Chrome 미설치 등) 배너 표시
+      setTimeout(() => setShow(true), 1500);
+    } else {
+      // iOS: 자동 전환 불가 → 배너로 안내
+      setShow(true);
+    }
+  }, [pathname]);
+
+  const handleCopy = () => {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(window.location.href).then(() => {
+        setUrlCopied(true);
+        setTimeout(() => setUrlCopied(false), 3000);
+      });
+    }
+  };
+
+  if (!show) return null;
+
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[100] p-3">
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-800/40 p-4 space-y-3 shadow-lg max-w-lg mx-auto">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-start gap-2.5">
+            <span className="text-lg flex-shrink-0">⚠️</span>
+            <div>
+              <p className="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                {inAppName} 앱에서는 일부 기능이 제한됩니다
+              </p>
+              <p className="text-xs text-amber-700 dark:text-amber-400 mt-1 leading-relaxed">
+                {isIOS ? 'Safari에서 열어 정상적으로 이용해 주세요.' : '외부 브라우저에서 이용해 주세요.'}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => setShow(false)}
+            className="text-amber-600 hover:text-amber-800 text-lg leading-none flex-shrink-0 p-1"
+            aria-label="닫기"
+          >
+            ✕
+          </button>
+        </div>
+        <button
+          onClick={handleCopy}
+          className="w-full flex items-center justify-center gap-2 py-2.5 rounded-xl bg-amber-500 text-white text-sm font-semibold hover:bg-amber-600 transition-colors"
+        >
+          {urlCopied ? '주소 복사됨! Safari 주소창에 붙여넣기 해주세요' : '주소 복사하기'}
+        </button>
+        {isIOS && (
+          <p className="text-[11px] text-amber-600 dark:text-amber-500 text-center">
+            Safari 주소창에 붙여넣기 후 이용해 주세요
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/meeting-calendar.tsx
+++ b/components/meeting-calendar.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { format, isToday, addMonths, subMonths, subDays } from 'date-fns';
+import { format, isToday, addMonths, subMonths } from 'date-fns';
 import { ko } from 'date-fns/locale';
-import { ChevronLeft, ChevronRight, Lock } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Lock, CalendarDays } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import {
   fetchDailyAvailability,
@@ -17,15 +18,10 @@ import type {
   TimeSlotAvailability,
   DailyCountDto,
   ParticipantTimeStatus,
+  MeetingParticipant,
 } from '@/types/meeting';
 import { toast } from '@/hooks/use-toast';
 import { buildMonthGrid } from '@/lib/helpers';
-
-// 헬퍼 함수: time 문자열 ("HH:00")을 슬롯 번호(0~23)로 변환 (현재는 미사용이지만 남겨둠)
-const getSlotNumberFromTime = (time: string): number => {
-  const [hour] = time.split(':').map(Number);
-  return hour;
-};
 
 interface MeetingCalendarProps {
   meeting: Meeting;
@@ -34,32 +30,14 @@ interface MeetingCalendarProps {
   readonly?: boolean;
 }
 
-// KST(+9) 기준으로 UTC 날짜가 바뀌는 경계 (0~8 / 9~23 구분)
-const TIMEZONE_OFFSET_HOURS = 9;
-
-/**
- * 선택된 슬롯(slots)을 기준으로,
- * - 슬롯 전체가 0~8이거나, 9~23에만 있으면 → 1개의 payload
- * - 0~8, 9~23을 모두 포함하면 → 전날/당일 기준으로 2개의 payload
- *   (슬롯 인덱스는 그대로, 날짜만 분리)
- */
-// 항상 선택한 날짜에 대해 하나의 payload만 생성
 const buildPatchPayloadForSlots = (
   selectedDate: Date,
   slots: number[],
   status: 'POSSIBLE' | 'IMPOSSIBLE'
 ): AvailabilitySlotUpdatePayload[] => {
   if (slots.length === 0) return [];
-
   const dateStr = format(selectedDate, 'yyyy-MM-dd');
-
-  return [
-    {
-      date: dateStr,
-      slots: Array.from(new Set(slots)).sort((a, b) => a - b),
-      status,
-    },
-  ];
+  return [{ date: dateStr, slots: Array.from(new Set(slots)).sort((a, b) => a - b), status }];
 };
 
 export function MeetingCalendar({
@@ -70,51 +48,60 @@ export function MeetingCalendar({
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [view, setView] = useState<'month' | 'day'>('month');
-  const [dailyStats, setDailyStats] = useState<Record<string, DailyCountDto>>(
-    {}
-  );
+  const [dailyStats, setDailyStats] = useState<Record<string, DailyCountDto>>({});
 
-  const initialParticipant = meeting.participants?.find(
-    (p) => p.userId === currentUserId
-  );
-  const [participantTimeStatuses, setParticipantTimeStatuses] = useState<
-    ParticipantTimeStatus[]
-  >(initialParticipant?.timeStatuses || []);
+  // 로컬 participant 상태 - PATCH 후 즉각 반영용
+  const [localParticipant, setLocalParticipant] = useState<MeetingParticipant | null>(null);
 
   const [slots, setSlots] = useState<TimeSlotAvailability[]>([]);
 
+  // 일 뷰 드래그
   const [isDragging, setIsDragging] = useState(false);
   const [dragStartIdx, setDragStartIdx] = useState<number | null>(null);
   const [dragEndIdx, setDragEndIdx] = useState<number | null>(null);
-  const [dragTargetStatus, setDragTargetStatus] = useState<
-    'POSSIBLE' | 'IMPOSSIBLE' | null
-  >(null);
+  const [dragTargetStatus, setDragTargetStatus] = useState<'POSSIBLE' | 'IMPOSSIBLE' | null>(null);
+  // 일 뷰 모바일 토글
+  const [dayDragMode, setDayDragMode] = useState(false);
+
+  // 월 뷰 드래그
+  const [monthDragging, setMonthDragging] = useState(false);
+  const [monthDragDates, setMonthDragDates] = useState<Set<string>>(new Set());
+  const [monthDragTarget, setMonthDragTarget] = useState<'POSSIBLE' | 'IMPOSSIBLE'>('POSSIBLE');
+  const monthDragRef = useRef(false);
+  const monthDragStarted = useRef(false);
+  const monthMouseDownDate = useRef<Date | null>(null);
+  // 월 뷰 모바일 토글
+  const [monthDragMode, setMonthDragMode] = useState(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const currentParticipant = meeting.participants?.find(
-    (p) => p.userId === currentUserId
-  );
+  const currentParticipant = localParticipant ??
+    meeting.participants?.find((p) => p.userId === currentUserId) ?? null;
+
   const todayStatus = currentParticipant?.timeStatuses?.find(
     (ts) => selectedDate && ts.date === format(selectedDate, 'yyyy-MM-dd')
   );
 
   const totalParticipants = meeting.participants?.length || 0;
 
+  // meeting.participants 변경 시 로컬 상태 동기화
+  useEffect(() => {
+    const p = meeting.participants?.find((p) => p.userId === currentUserId);
+    if (p) setLocalParticipant({ ...p, timeStatuses: [...(p.timeStatuses || [])] });
+  }, [meeting.participants, currentUserId]);
+
   const generateDailySchedule = useCallback(
-    (date: Date): TimeSlotAvailability[] => {
-      const slots: TimeSlotAvailability[] = [];
+    (date: Date, overrideParticipant?: MeetingParticipant | null): TimeSlotAvailability[] => {
+      const result: TimeSlotAvailability[] = [];
       const dateStr = format(date, 'yyyy-MM-dd');
+      const effectiveParticipant = overrideParticipant !== undefined ? overrideParticipant : currentParticipant;
+      const effectiveTodayStatus = effectiveParticipant?.timeStatuses?.find(ts => ts.date === dateStr);
 
       for (let hour = 0; hour < 24; hour++) {
         const time = `${hour.toString().padStart(2, '0')}:00`;
-
         let availableCount = 0;
-        let myStatus: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET' = 'UNSET';
-
         const availableParticipants: string[] = [];
         const unavailableParticipants: string[] = [];
-        const unsetParticipants: string[] = [];
 
         const isCandidate =
           meeting.requirement.isAllDay ||
@@ -127,14 +114,10 @@ export function MeetingCalendar({
 
         if (meeting.participants) {
           meeting.participants.forEach((participant) => {
-            if (participant.status === 'PENDING') {
-              unsetParticipants.push(participant.name);
-              return;
-            }
-
-            const ts = participant.timeStatuses?.find(
-              (t) => t.date === dateStr
-            );
+            if (participant.status === 'PENDING') return;
+            const ts = participant.userId === currentUserId
+              ? effectiveTodayStatus
+              : participant.timeStatuses?.find((t) => t.date === dateStr);
             if (ts && ts.impossibleSlots?.includes(hour)) {
               unavailableParticipants.push(participant.name);
             } else {
@@ -144,92 +127,57 @@ export function MeetingCalendar({
           });
         }
 
-        if (currentParticipant && isCandidate) {
-          if (currentParticipant.status === 'PENDING') {
+        let myStatus: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET' = 'UNSET';
+        if (effectiveParticipant && isCandidate) {
+          if (effectiveParticipant.status === 'PENDING') {
             myStatus = 'UNSET';
-          } else if (
-            todayStatus &&
-            todayStatus.impossibleSlots?.includes(hour)
-          ) {
+          } else if (effectiveTodayStatus && effectiveTodayStatus.impossibleSlots?.includes(hour)) {
             myStatus = 'IMPOSSIBLE';
           } else {
             myStatus = 'POSSIBLE';
           }
         }
 
-        slots.push({
-          time,
-          availableCount,
-          totalParticipants,
-          isCandidate,
-          myStatus,
-          availableParticipants,
-          unavailableParticipants,
-        } as any);
+        result.push({ time, availableCount, totalParticipants, isCandidate, myStatus, availableParticipants, unavailableParticipants } as any);
       }
-
-      return slots;
+      return result;
     },
-    [meeting, currentParticipant, todayStatus, totalParticipants]
+    [meeting, currentParticipant, todayStatus, totalParticipants, currentUserId]
   );
 
   const loadDailyAvailability = useCallback(async () => {
     try {
       const stats = await fetchDailyAvailability(meeting.id);
       setDailyStats(stats);
-    } catch (error) {
-      console.error('Failed to load daily availability', error);
+    } catch {
       toast({ title: '가용 시간 정보를 불러오지 못했습니다.', variant: 'destructive' });
     }
   }, [meeting.id]);
 
   useEffect(() => {
     const initialDate = new Date(meeting.requirement.dateRangeStart);
-    setCurrentMonth(
-      new Date(initialDate.getFullYear(), initialDate.getMonth(), 1)
-    );
+    setCurrentMonth(new Date(initialDate.getFullYear(), initialDate.getMonth(), 1));
     loadDailyAvailability();
-
-    const initialParticipant = meeting.participants?.find(
-      (p) => p.userId === currentUserId
-    );
-    if (initialParticipant) {
-      setParticipantTimeStatuses(initialParticipant.timeStatuses || []);
-    }
-  }, [meeting.id, currentUserId, meeting.participants, loadDailyAvailability]);
+  }, [meeting.id, loadDailyAvailability]);
 
   useEffect(() => {
     if (view === 'day' && scrollRef.current) {
       setTimeout(() => {
-        const scrollContainer = scrollRef.current?.querySelector(
-          '[data-radix-scroll-area-viewport]'
-        );
-        if (scrollContainer) {
-          scrollContainer.scrollTop = 540;
-        }
+        scrollRef.current?.scrollTo({ top: 540 });
       }, 100);
     }
   }, [view]);
 
   const getDailyStats = (date: Date) => {
     const dateKey = format(date, 'yyyy-MM-dd');
-    const totalCount =
-      meeting.participants?.length || meeting.invitedUserIds?.length || 0;
+    const totalCount = meeting.participants?.length || meeting.invitedUserIds?.length || 0;
 
     if (!meeting.participants || meeting.participants.length === 0) {
-      return {
-        availableCount: 0,
-        totalParticipants: totalCount,
-        isFullyAvailable: false,
-      };
+      return { availableCount: 0, totalParticipants: totalCount, isFullyAvailable: false };
     }
 
-    // 후보 시간대 계산
     const candidateHours: number[] = [];
-    if (
-      meeting.requirement.isAllDay ||
-      meeting.requirement.timeConstraints.length === 0
-    ) {
+    if (meeting.requirement.isAllDay || meeting.requirement.timeConstraints.length === 0) {
       for (let h = 0; h < 24; h++) candidateHours.push(h);
     } else {
       meeting.requirement.timeConstraints.forEach((tc) => {
@@ -243,32 +191,30 @@ export function MeetingCalendar({
 
     let availableCount = 0;
     meeting.participants.forEach((participant) => {
-      if (participant.status === 'PENDING') {
-        return;
-      }
-
-      const ts = participant.timeStatuses?.find((t) => t.date === dateKey);
-      const impossibleSlots = ts?.impossibleSlots || [];
-
-      const hasAvailableSlot = candidateHours.some(
-        (hour) => !impossibleSlots.includes(hour)
-      );
-
-      if (hasAvailableSlot) {
+      if (participant.status === 'PENDING') return;
+      const effectiveTs = participant.userId === currentUserId
+        ? localParticipant?.timeStatuses?.find(t => t.date === dateKey)
+        : participant.timeStatuses?.find((t) => t.date === dateKey);
+      const impossibleSlots = effectiveTs?.impossibleSlots || [];
+      if (candidateHours.some((hour) => !impossibleSlots.includes(hour))) {
         availableCount++;
       }
     });
 
-    const pendingCount = meeting.participants.filter(
-      (p) => p.status === 'PENDING'
-    ).length;
-
+    const pendingCount = meeting.participants.filter((p) => p.status === 'PENDING').length;
     return {
       availableCount,
       totalParticipants: totalCount,
-      isFullyAvailable:
-        availableCount === totalCount && totalCount > 0 && pendingCount === 0,
+      isFullyAvailable: availableCount === totalCount && totalCount > 0 && pendingCount === 0,
     };
+  };
+
+  const isDateInRange = (date: Date) => {
+    const start = new Date(meeting.requirement.dateRangeStart);
+    const end = new Date(meeting.requirement.dateRangeEnd);
+    start.setHours(0, 0, 0, 0);
+    end.setHours(23, 59, 59, 999);
+    return date >= start && date <= end;
   };
 
   const handlePrevMonth = () => setCurrentMonth(subMonths(currentMonth, 1));
@@ -283,72 +229,153 @@ export function MeetingCalendar({
   const handleBackToMonth = () => {
     setView('month');
     setSelectedDate(null);
-    loadDailyAvailability();
   };
 
-  const isDateInRange = (date: Date) => {
-    const start = new Date(meeting.requirement.dateRangeStart);
-    const end = new Date(meeting.requirement.dateRangeEnd);
-    start.setHours(0, 0, 0, 0);
-    end.setHours(23, 59, 59, 999);
-    return date >= start && date <= end;
+  // ── 월 뷰: localParticipant 즉각 반영 헬퍼 ──
+  const applyMonthDragLocally = (dates: string[], target: 'POSSIBLE' | 'IMPOSSIBLE', candidateSlotsMap: Record<string, number[]>) => {
+    setLocalParticipant(prev => {
+      if (!prev) return prev;
+      const updated = { ...prev, timeStatuses: [...(prev.timeStatuses || [])] };
+      dates.forEach(dateStr => {
+        const slotList = candidateSlotsMap[dateStr] || [];
+        const idx = updated.timeStatuses.findIndex(ts => ts.date === dateStr);
+        if (idx >= 0) {
+          let existing = [...(updated.timeStatuses[idx].impossibleSlots || [])];
+          if (target === 'IMPOSSIBLE') {
+            existing = Array.from(new Set([...existing, ...slotList]));
+          } else {
+            existing = existing.filter(s => !slotList.includes(s));
+          }
+          updated.timeStatuses[idx] = { ...updated.timeStatuses[idx], impossibleSlots: existing };
+        } else if (target === 'IMPOSSIBLE' && slotList.length > 0) {
+          updated.timeStatuses.push({ date: dateStr, impossibleSlots: slotList, status: 'IMPOSSIBLE' });
+        }
+      });
+      return updated;
+    });
   };
 
-  // 클릭/드래그 공통 시작점: 클릭도 "길이 1짜리 드래그"로 취급
-  const handleMouseDown = (
-    index: number,
-    status: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET'
-  ) => {
-    if (readonly) return;
-
-    setIsDragging(true);
-    setDragStartIdx(index);
-    setDragEndIdx(index);
-
-    const targetStatus: 'POSSIBLE' | 'IMPOSSIBLE' =
-      status === 'POSSIBLE' || status === 'UNSET' ? 'IMPOSSIBLE' : 'POSSIBLE';
-
-    setDragTargetStatus(targetStatus);
-  };
-
-  const handleMouseEnter = (index: number) => {
-    if (isDragging && !readonly) {
-      setDragEndIdx(index);
+  const getMonthCandidateSlots = (): number[] => {
+    const result: number[] = [];
+    if (meeting.requirement.isAllDay || meeting.requirement.timeConstraints.length === 0) {
+      for (let h = 0; h < 24; h++) result.push(h);
+    } else {
+      meeting.requirement.timeConstraints.forEach(tc => {
+        const [startH] = tc.startTime.split(':').map(Number);
+        const [endH] = tc.endTime.split(':').map(Number);
+        for (let h = startH; h < endH; h++) {
+          if (!result.includes(h)) result.push(h);
+        }
+      });
     }
+    return result;
   };
 
-  const handleMouseUp = async () => {
-    if (readonly) {
-      setIsDragging(false);
+  // ── 월 뷰 드래그 핸들러 ──
+  const handleMonthDateMouseDown = (date: Date, isMobile: boolean) => {
+    if (readonly) return;
+    if (isMobile && !monthDragMode) return;
+    monthDragRef.current = true;
+    monthDragStarted.current = false;
+    monthMouseDownDate.current = date;
+
+    const dateStr = format(date, 'yyyy-MM-dd');
+    const ts = localParticipant?.timeStatuses?.find(t => t.date === dateStr);
+    const hasImpossible = ts && ts.impossibleSlots && ts.impossibleSlots.length > 0;
+    const target: 'POSSIBLE' | 'IMPOSSIBLE' = hasImpossible ? 'POSSIBLE' : 'IMPOSSIBLE';
+    setMonthDragTarget(target);
+    setMonthDragDates(new Set([dateStr]));
+  };
+
+  const handleMonthDateMouseEnter = (date: Date) => {
+    if (!monthDragRef.current) return;
+    if (!isDateInRange(date)) return;
+    monthDragStarted.current = true;
+    setMonthDragging(true);
+    const dateStr = format(date, 'yyyy-MM-dd');
+    setMonthDragDates(prev => new Set([...prev, dateStr]));
+  };
+
+  const handleMonthDateMouseUp = async (clickedDate?: Date) => {
+    if (!monthDragRef.current) return;
+
+    const wasDrag = monthDragStarted.current;
+    monthDragRef.current = false;
+    monthDragStarted.current = false;
+    setMonthDragging(false);
+
+    // PC 단순 클릭 → 일 뷰 이동
+    if (!wasDrag && clickedDate && !monthDragMode) {
+      setMonthDragDates(new Set());
+      handleDateClick(clickedDate);
       return;
     }
 
-    if (
-      !isDragging ||
-      dragStartIdx === null ||
-      dragEndIdx === null ||
-      !dragTargetStatus ||
-      !selectedDate ||
-      !currentParticipant
-    ) {
+    const dates = Array.from(monthDragDates);
+    setMonthDragDates(new Set());
+    if (dates.length === 0) return;
+
+    const candidateSlots = getMonthCandidateSlots();
+    if (candidateSlots.length === 0) return;
+
+    const candidateSlotsMap: Record<string, number[]> = {};
+    dates.forEach(d => { candidateSlotsMap[d] = candidateSlots; });
+
+    // 즉각 로컬 반영
+    applyMonthDragLocally(dates, monthDragTarget, candidateSlotsMap);
+
+    try {
+      for (const dateStr of dates) {
+        const payloads = buildPatchPayloadForSlots(
+          new Date(dateStr + 'T12:00:00'),
+          candidateSlots,
+          monthDragTarget
+        );
+        for (const payload of payloads) {
+          await patchParticipantAvailability(meeting.id, [payload]);
+        }
+      }
+      toast({ title: `${dates.length}일 일정이 업데이트되었습니다.` });
+    } catch {
+      const p = meeting.participants?.find(p => p.userId === currentUserId);
+      if (p) setLocalParticipant({ ...p, timeStatuses: [...(p.timeStatuses || [])] });
+      toast({ title: '일정 업데이트에 실패했습니다.', variant: 'destructive' });
+    }
+  };
+
+  // ── 일 뷰 드래그 핸들러 ──
+  const handleMouseDown = (index: number, status: 'POSSIBLE' | 'IMPOSSIBLE' | 'UNSET') => {
+    if (readonly) return;
+    setIsDragging(true);
+    setDragStartIdx(index);
+    setDragEndIdx(index);
+    setDragTargetStatus(status === 'POSSIBLE' || status === 'UNSET' ? 'IMPOSSIBLE' : 'POSSIBLE');
+  };
+
+  const handleMouseEnter = (index: number) => {
+    if (isDragging && !readonly) setDragEndIdx(index);
+  };
+
+  const handleMouseUp = async () => {
+    if (readonly) { setIsDragging(false); return; }
+    if (!isDragging || dragStartIdx === null || dragEndIdx === null || !dragTargetStatus || !selectedDate || !currentParticipant) {
       setIsDragging(false);
       return;
     }
 
     const start = Math.min(dragStartIdx, dragEndIdx);
     const end = Math.max(dragStartIdx, dragEndIdx);
-
     const currentSlots = generateDailySchedule(selectedDate);
-    const selectedSlots: number[] = [];
+    const selectedSlotNums: number[] = [];
 
     for (let i = start; i <= end; i++) {
       if (currentSlots[i]?.isCandidate) {
         const [hour] = currentSlots[i].time.split(':').map(Number);
-        selectedSlots.push(hour);
+        selectedSlotNums.push(hour);
       }
     }
 
-    if (selectedSlots.length === 0) {
+    if (selectedSlotNums.length === 0) {
       setIsDragging(false);
       setDragStartIdx(null);
       setDragEndIdx(null);
@@ -356,68 +383,41 @@ export function MeetingCalendar({
       return;
     }
 
-    // UTC 경계 기준으로 payload 분리
-    const payloads = buildPatchPayloadForSlots(
-      selectedDate,
-      selectedSlots,
-      dragTargetStatus
-    );
+    const payloads = buildPatchPayloadForSlots(selectedDate, selectedSlotNums, dragTargetStatus);
+
+    // 즉각 로컬 반영
+    const dateStr = format(selectedDate, 'yyyy-MM-dd');
+    setLocalParticipant(prev => {
+      if (!prev) return prev;
+      const updated = { ...prev, timeStatuses: [...(prev.timeStatuses || [])] };
+      const idx = updated.timeStatuses.findIndex(ts => ts.date === dateStr);
+      if (idx >= 0) {
+        let existing = [...(updated.timeStatuses[idx].impossibleSlots || [])];
+        if (dragTargetStatus === 'IMPOSSIBLE') {
+          existing = Array.from(new Set([...existing, ...selectedSlotNums]));
+        } else {
+          existing = existing.filter(s => !selectedSlotNums.includes(s));
+        }
+        updated.timeStatuses[idx] = { ...updated.timeStatuses[idx], impossibleSlots: existing };
+      } else if (dragTargetStatus === 'IMPOSSIBLE') {
+        updated.timeStatuses.push({ date: dateStr, impossibleSlots: selectedSlotNums, status: 'IMPOSSIBLE' });
+      }
+      return updated;
+    });
+
+    setSlots(prev => prev.map((s, idx) => {
+      if (idx >= start && idx <= end && s.isCandidate) return { ...s, myStatus: dragTargetStatus! };
+      return s;
+    }));
 
     try {
-      // 분리된 payload 각각 PATCH
       for (const payload of payloads) {
         await patchParticipantAvailability(meeting.id, [payload]);
       }
-
-      const dateStr = format(selectedDate, 'yyyy-MM-dd');
-      const updatedParticipant = { ...currentParticipant };
-      const statusIndex = updatedParticipant.timeStatuses?.findIndex(
-        (ts) => ts.date === dateStr
-      );
-
-      if (statusIndex !== undefined && statusIndex >= 0) {
-        let existingSlots =
-          updatedParticipant.timeStatuses![statusIndex].impossibleSlots || [];
-        if (dragTargetStatus === 'IMPOSSIBLE') {
-          existingSlots = Array.from(
-            new Set([...existingSlots, ...selectedSlots])
-          );
-        } else {
-          existingSlots = existingSlots.filter(
-            (s) => !selectedSlots.includes(s)
-          );
-        }
-        updatedParticipant.timeStatuses![statusIndex].impossibleSlots =
-          existingSlots;
-      } else {
-        if (!updatedParticipant.timeStatuses)
-          updatedParticipant.timeStatuses = [];
-        updatedParticipant.timeStatuses.push({
-          date: dateStr,
-          impossibleSlots:
-            dragTargetStatus === 'IMPOSSIBLE' ? selectedSlots : [],
-          status: 'IMPOSSIBLE',
-        });
-      }
-
-      setSlots((prevSlots) =>
-        prevSlots.map((s, idx) => {
-          if (idx >= start && idx <= end && s.isCandidate) {
-            return { ...s, myStatus: dragTargetStatus };
-          }
-          return s;
-        })
-      );
-
-      await loadDailyAvailability();
-    } catch (error) {
-      console.error('Failed to batch update availability', error);
+    } catch {
+      const p = meeting.participants?.find(p => p.userId === currentUserId);
+      if (p) setLocalParticipant({ ...p, timeStatuses: [...(p.timeStatuses || [])] });
       toast({ title: '시간 업데이트에 실패했습니다.', variant: 'destructive' });
-      toast({
-        title: '업데이트 실패',
-        description: '일정을 업데이트하지 못했습니다.',
-        variant: 'destructive',
-      });
     } finally {
       setIsDragging(false);
       setDragStartIdx(null);
@@ -426,6 +426,7 @@ export function MeetingCalendar({
     }
   };
 
+  // ── 렌더: 월 뷰 ──
   const renderMonthView = () => {
     const y = currentMonth.getFullYear();
     const m = currentMonth.getMonth();
@@ -436,77 +437,104 @@ export function MeetingCalendar({
         {readonly && (
           <div className="px-3 py-2 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 flex items-center gap-2">
             <Lock className="h-4 w-4 text-amber-600" />
-            <span className="text-sm text-amber-700 dark:text-amber-300">
-              읽기 전용 모드
-            </span>
+            <span className="text-sm text-amber-700 dark:text-amber-300">읽기 전용 모드</span>
           </div>
         )}
+
+        {/* 헤더: 월 네비게이션 + 모바일 전용 토글 */}
         <div className="flex items-center justify-between bg-gradient-to-r from-primary/10 to-primary/5 p-3 shrink-0">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handlePrevMonth}
-            className="hover:bg-primary/10"
-          >
+          <Button variant="ghost" size="icon" onClick={handlePrevMonth} className="hover:bg-primary/10">
             <ChevronLeft className="h-5 w-5" />
           </Button>
           <h2 className="text-lg font-bold text-foreground flex-1 text-center">
             {format(currentMonth, 'yyyy년 M월', { locale: ko })}
           </h2>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleNextMonth}
-            className="hover:bg-primary/10"
-          >
+          {/* 모바일 전용 드래그 모드 토글 */}
+          {!readonly && (
+            <div className="flex items-center gap-1.5 sm:hidden">
+              <CalendarDays className={cn('h-3.5 w-3.5', monthDragMode ? 'text-primary' : 'text-muted-foreground')} />
+              <Switch
+                checked={monthDragMode}
+                onCheckedChange={(v) => { setMonthDragMode(v); setMonthDragDates(new Set()); }}
+              />
+            </div>
+          )}
+          <Button variant="ghost" size="icon" onClick={handleNextMonth} className="hover:bg-primary/10">
             <ChevronRight className="h-5 w-5" />
           </Button>
         </div>
 
+        {/* 모바일 드래그 모드 안내 배너 */}
+        {!readonly && monthDragMode && (
+          <div className="sm:hidden px-3 py-1.5 bg-primary/5 border-b border-primary/20 text-center">
+            <span className="text-[11px] text-primary font-medium">드래그로 여러 날짜 참석 여부를 한 번에 설정</span>
+          </div>
+        )}
+
         <div className="flex-1 p-2 sm:p-3 flex flex-col">
           <div className="mb-2 grid grid-cols-7 gap-1 text-center">
             {['일', '월', '화', '수', '목', '금', '토'].map((day, idx) => (
-              <div
-                key={day}
-                className={cn(
-                  'text-xs sm:text-sm font-bold',
-                  idx === 0
-                    ? 'text-red-500'
-                    : idx === 6
-                    ? 'text-blue-500'
-                    : 'text-muted-foreground'
-                )}
-              >
-                {day}
-              </div>
+              <div key={day} className={cn('text-xs sm:text-sm font-bold',
+                idx === 0 ? 'text-red-500' : idx === 6 ? 'text-blue-500' : 'text-muted-foreground'
+              )}>{day}</div>
             ))}
           </div>
 
-          <div className="flex-1 flex flex-col gap-1">
+          <div
+            className="flex-1 flex flex-col gap-1"
+            onMouseUp={() => { if (monthDragRef.current) handleMonthDateMouseUp(); }}
+            onMouseLeave={() => { if (monthDragRef.current) handleMonthDateMouseUp(); }}
+          >
             {grid.map((week, weekIdx) => (
-              <div
-                key={`week-${weekIdx}`}
-                className="grid grid-cols-7 gap-1 flex-1"
-              >
+              <div key={`week-${weekIdx}`} className="grid grid-cols-7 gap-1 flex-1">
                 {week.map((date, colIdx) => {
-                  if (!date)
-                    return <div key={`empty-${colIdx}`} className="min-h-0" />;
+                  if (!date) return <div key={`empty-${colIdx}`} className="min-h-0" />;
 
                   const isInRange = isDateInRange(date);
                   const dayNum = date.getDay();
                   const stats = getDailyStats(date);
+                  const dateStr = format(date, 'yyyy-MM-dd');
+                  const isDragHighlighted = monthDragging && monthDragDates.has(dateStr) && isInRange;
 
                   return (
                     <button
                       key={date.toISOString()}
-                      onClick={() => isInRange && handleDateClick(date)}
+                      data-date={dateStr}
                       disabled={!isInRange}
+                      onMouseDown={(e) => {
+                        if (!isInRange) return;
+                        e.preventDefault();
+                        handleMonthDateMouseDown(date, false);
+                      }}
+                      onMouseEnter={() => handleMonthDateMouseEnter(date)}
+                      onMouseUp={() => isInRange && handleMonthDateMouseUp(date)}
+                      onTouchStart={(e) => {
+                        if (!isInRange || !monthDragMode) return;
+                        e.preventDefault();
+                        handleMonthDateMouseDown(date, true);
+                      }}
+                      onTouchMove={(e) => {
+                        if (!monthDragMode) return;
+                        e.preventDefault();
+                        const touch = e.touches[0];
+                        const el = document.elementFromPoint(touch.clientX, touch.clientY);
+                        const ds = el?.getAttribute('data-date');
+                        if (ds) handleMonthDateMouseEnter(new Date(ds + 'T12:00:00'));
+                      }}
+                      onTouchEnd={() => handleMonthDateMouseUp()}
                       className={cn(
                         'flex flex-col items-center justify-center rounded-lg text-xs sm:text-sm font-medium transition-all min-h-[52px] sm:min-h-[64px]',
                         isToday(date) && 'ring-2 ring-primary',
                         isInRange
-                          ? 'hover:bg-primary/20 cursor-pointer'
+                          ? monthDragMode
+                            ? 'cursor-crosshair hover:opacity-80 sm:cursor-pointer'
+                            : 'hover:bg-primary/20 cursor-pointer'
                           : 'opacity-40 cursor-not-allowed',
+                        isDragHighlighted
+                          ? monthDragTarget === 'IMPOSSIBLE'
+                            ? 'ring-2 ring-rose-400 ring-inset brightness-90'
+                            : 'ring-2 ring-emerald-400 ring-inset brightness-110'
+                          : '',
                         stats.isFullyAvailable && isInRange
                           ? 'bg-green-100 dark:bg-green-900/30'
                           : stats.availableCount > 0 && isInRange
@@ -516,18 +544,9 @@ export function MeetingCalendar({
                           : ''
                       )}
                     >
-                      <span
-                        className={cn(
-                          'font-semibold',
-                          dayNum === 0
-                            ? 'text-red-500'
-                            : dayNum === 6
-                            ? 'text-blue-500'
-                            : ''
-                        )}
-                      >
-                        {date.getDate()}
-                      </span>
+                      <span className={cn('font-semibold',
+                        dayNum === 0 ? 'text-red-500' : dayNum === 6 ? 'text-blue-500' : ''
+                      )}>{date.getDate()}</span>
                       {isInRange && (
                         <span className="text-[10px] font-medium text-muted-foreground">
                           {stats.availableCount}/{stats.totalParticipants}
@@ -554,33 +573,33 @@ export function MeetingCalendar({
               <span className="text-muted-foreground">가능 인원 없음</span>
             </div>
           </div>
+          {!readonly && (
+            <p className="hidden sm:block mt-2 text-[11px] text-center text-muted-foreground">
+              클릭하면 일 화면으로 이동 · 드래그하면 여러 날짜 참석 여부를 한 번에 설정
+            </p>
+          )}
         </div>
       </Card>
     );
   };
 
+  // ── 렌더: 일 뷰 ──
   const renderDayView = () => {
     if (!selectedDate) return null;
-
     const currentSlots = generateDailySchedule(selectedDate);
 
     return (
-      <Card className="flex flex-col overflow-hidden shadow-lg h-full">
+      <Card className="flex flex-col overflow-hidden shadow-lg h-full relative">
         {readonly && (
           <div className="px-3 py-2 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 flex items-center gap-2">
             <Lock className="h-4 w-4 text-amber-600" />
-            <span className="text-sm text-amber-700 dark:text-amber-300">
-              읽기 전용 모드
-            </span>
+            <span className="text-sm text-amber-700 dark:text-amber-300">읽기 전용 모드</span>
           </div>
         )}
+
+        {/* 헤더 */}
         <div className="flex items-center justify-between bg-gradient-to-r from-primary/10 to-primary/5 p-3 shrink-0">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleBackToMonth}
-            className="hover:bg-primary/10"
-          >
+          <Button variant="ghost" size="icon" onClick={handleBackToMonth} className="hover:bg-primary/10">
             <ChevronLeft className="h-5 w-5" />
           </Button>
           <h2 className="text-lg font-bold text-foreground">
@@ -589,14 +608,14 @@ export function MeetingCalendar({
           <div className="w-10" />
         </div>
 
+        {/* 스크롤 영역 - dayDragMode ON 시 터치 스크롤 차단 */}
         <div
-          className="flex-1 overflow-y-auto relative"
+          className={cn('flex-1 relative', dayDragMode ? 'overflow-hidden touch-none' : 'overflow-y-auto')}
           ref={scrollRef}
           onMouseUp={handleMouseUp}
           onMouseLeave={handleMouseUp}
         >
           <div className="relative">
-            {/* 시간대 레이블들 - 1시부터 23시까지 (B 스타일 레이아웃) */}
             {Array.from({ length: 23 }).map((_, idx) => {
               const hour = idx + 1;
               return (
@@ -612,18 +631,12 @@ export function MeetingCalendar({
               );
             })}
 
-            {/* 시간대 슬롯들 - 24개 모두 표시 (0~23시) */}
             <div className="pl-16 border-l">
               {currentSlots.map((slot, index) => {
                 let isAvailable = slot.myStatus === 'POSSIBLE';
                 let isUnavailable = slot.myStatus === 'IMPOSSIBLE';
 
-                if (
-                  isDragging &&
-                  dragStartIdx !== null &&
-                  dragEndIdx !== null &&
-                  dragTargetStatus
-                ) {
+                if (isDragging && dragStartIdx !== null && dragEndIdx !== null && dragTargetStatus) {
                   const start = Math.min(dragStartIdx, dragEndIdx);
                   const end = Math.max(dragStartIdx, dragEndIdx);
                   if (index >= start && index <= end && slot.isCandidate) {
@@ -636,130 +649,122 @@ export function MeetingCalendar({
                   availableParticipants?: string[];
                   unavailableParticipants?: string[];
                 };
-
-                const availableRatio =
-                  slot.totalParticipants > 0
-                    ? slot.availableCount / slot.totalParticipants
-                    : 0;
+                const availableRatio = slot.totalParticipants > 0 ? slot.availableCount / slot.totalParticipants : 0;
                 const unavailableRatio = 1 - availableRatio;
-
-                const unavailableCount =
-                  slot.totalParticipants - slot.availableCount;
+                const unavailableCount = slot.totalParticipants - slot.availableCount;
 
                 return (
                   <div
                     key={index}
                     onMouseDown={(e) => {
-                      if (slot.isCandidate) {
+                      if (slot.isCandidate && !readonly) {
                         e.preventDefault();
                         handleMouseDown(index, slot.myStatus);
                       }
                     }}
                     onMouseEnter={() => handleMouseEnter(index)}
-                    // 클릭은 드래그로만 처리하므로, onClick에서는 동작 안 함
-                    onClick={(e) => {
+                    onTouchStart={(e) => {
+                      if (!slot.isCandidate || readonly || !dayDragMode) return;
                       e.preventDefault();
+                      handleMouseDown(index, slot.myStatus);
                     }}
+                    onTouchMove={(e) => {
+                      if (!dayDragMode || readonly) return;
+                      e.preventDefault();
+                      if (!scrollRef.current) return;
+                      const touch = e.touches[0];
+                      const containerRect = scrollRef.current.getBoundingClientRect();
+                      const scrollTop = scrollRef.current.scrollTop;
+                      const relativeY = touch.clientY - containerRect.top + scrollTop;
+                      const SLOT_HEIGHT = 56;
+                      const calculatedIdx = Math.floor(relativeY / SLOT_HEIGHT);
+                      const clampedIdx = Math.max(0, Math.min(23, calculatedIdx));
+                      handleMouseEnter(clampedIdx);
+                    }}
+                    onTouchEnd={handleMouseUp}
+                    data-slot-index={index}
                     className={cn(
                       'h-14 border-t border-border/30 relative flex items-center transition-colors select-none',
                       slot.isCandidate
-                        ? readonly
-                          ? 'cursor-not-allowed opacity-50'
-                          : 'cursor-pointer hover:opacity-90'
+                        ? readonly ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:opacity-90'
                         : 'bg-muted/10 cursor-not-allowed opacity-50',
-                      isDragging &&
-                        dragStartIdx !== null &&
-                        dragEndIdx !== null &&
+                      isDragging && dragStartIdx !== null && dragEndIdx !== null &&
                         index >= Math.min(dragStartIdx, dragEndIdx) &&
-                        index <= Math.max(dragStartIdx, dragEndIdx) &&
-                        slot.isCandidate
-                        ? 'ring-2 ring-primary ring-inset'
-                        : ''
+                        index <= Math.max(dragStartIdx, dragEndIdx) && slot.isCandidate
+                        ? 'ring-2 ring-primary ring-inset' : ''
                     )}
                   >
-                    {/* 가능 영역 (B 스타일 바) */}
                     {slot.isCandidate && slot.availableCount > 0 && (
                       <div
                         className="absolute left-0 top-0 bottom-0 bg-teal-50 dark:bg-teal-900/40 transition-all duration-300 flex items-center justify-start px-2 sm:px-3 overflow-hidden"
                         style={{ width: `${availableRatio * 100}%` }}
                       >
                         <div className="flex flex-col min-w-0">
-                          <span className="text-xs font-bold text-teal-700 dark:text-teal-300 whitespace-nowrap">
-                            {slot.availableCount}명 가능
-                          </span>
-                          {slotWithParticipants.availableParticipants &&
-                            slotWithParticipants.availableParticipants.length >
-                              0 && (
-                              <span className="text-[10px] text-teal-600 dark:text-teal-400 truncate max-w-full">
-                                {slotWithParticipants.availableParticipants.join(
-                                  ', '
-                                )}
-                              </span>
-                            )}
+                          <span className="text-xs font-bold text-teal-700 dark:text-teal-300 whitespace-nowrap">{slot.availableCount}명 가능</span>
+                          {slotWithParticipants.availableParticipants && slotWithParticipants.availableParticipants.length > 0 && (
+                            <span className="text-[10px] text-teal-600 dark:text-teal-400 truncate max-w-full">
+                              {slotWithParticipants.availableParticipants.join(', ')}
+                            </span>
+                          )}
                         </div>
                       </div>
                     )}
-
-                    {/* 불가능 영역 (B 스타일 바) */}
                     {slot.isCandidate && unavailableCount > 0 && (
                       <div
                         className="absolute top-0 bottom-0 bg-pink-50 dark:bg-pink-900/30 transition-all duration-300 flex items-center justify-start px-2 sm:px-3 overflow-hidden"
-                        style={{
-                          right: 0,
-                          width: `${unavailableRatio * 100}%`,
-                          paddingRight: '80px',
-                        }}
+                        style={{ right: 0, width: `${unavailableRatio * 100}%`, paddingRight: '80px' }}
                       >
                         <div className="flex flex-col items-start min-w-0">
-                          <span className="text-xs font-bold text-pink-700 dark:text-pink-300 whitespace-nowrap">
-                            {unavailableCount}명 불가
-                          </span>
-                          {slotWithParticipants.unavailableParticipants &&
-                            slotWithParticipants.unavailableParticipants
-                              .length > 0 && (
-                              <span className="text-[10px] text-pink-600 dark:text-pink-400 truncate max-w-full">
-                                {slotWithParticipants.unavailableParticipants.join(
-                                  ', '
-                                )}
-                              </span>
-                            )}
+                          <span className="text-xs font-bold text-pink-700 dark:text-pink-300 whitespace-nowrap">{unavailableCount}명 불가</span>
+                          {slotWithParticipants.unavailableParticipants && slotWithParticipants.unavailableParticipants.length > 0 && (
+                            <span className="text-[10px] text-pink-600 dark:text-pink-400 truncate max-w-full">
+                              {slotWithParticipants.unavailableParticipants.join(', ')}
+                            </span>
+                          )}
                         </div>
                       </div>
                     )}
-
-                    {/* 오른쪽 내 상태 뱃지 */}
                     <div className="absolute right-2 flex items-center gap-2 z-10 pointer-events-none">
                       {isAvailable && (
                         <div className="flex items-center gap-1 text-teal-700 dark:text-teal-300 bg-teal-100/95 dark:bg-teal-900/80 px-2 py-1 rounded-full shadow-sm">
                           <div className="w-2 h-2 rounded-full bg-emerald-500 shrink-0" />
-                          <span className="text-xs font-bold hidden sm:inline">
-                            참여 가능
-                          </span>
+                          <span className="text-xs font-bold hidden sm:inline">참여 가능</span>
                         </div>
                       )}
                       {isUnavailable && (
                         <div className="flex items-center gap-1 text-rose-700 bg-rose-100/95 dark:bg-rose-900/80 px-2 py-1 rounded-full shadow-sm">
                           <div className="w-2 h-2 rounded-full bg-rose-500 shrink-0" />
-                          <span className="text-xs font-bold hidden sm:inline">
-                            참여 불가
-                          </span>
+                          <span className="text-xs font-bold hidden sm:inline">참여 불가</span>
                         </div>
                       )}
                     </div>
-
-                    {/* 왼쪽 세로 표시선 */}
-                    {isAvailable && (
-                      <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-emerald-500 z-10" />
-                    )}
-                    {isUnavailable && (
-                      <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-rose-500 z-10" />
-                    )}
+                    {isAvailable && <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-emerald-500 z-10" />}
+                    {isUnavailable && <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-rose-500 z-10" />}
                   </div>
                 );
               })}
             </div>
           </div>
         </div>
+
+        {/* 모바일 전용 고정 드래그 토글 */}
+        {!readonly && (
+          <div className={cn(
+            'sm:hidden fixed bottom-20 right-4 z-50',
+            'flex items-center gap-2 px-3 py-2 rounded-full shadow-lg border',
+            dayDragMode
+              ? 'bg-primary text-primary-foreground border-primary'
+              : 'bg-background text-foreground border-border'
+          )}>
+            <CalendarDays className="h-3.5 w-3.5 flex-shrink-0" />
+            <span className="text-xs font-medium whitespace-nowrap">다중 선택</span>
+            <Switch
+              checked={dayDragMode}
+              onCheckedChange={setDayDragMode}
+              className="scale-75"
+            />
+          </div>
+        )}
       </Card>
     );
   };

--- a/components/onboarding-banner.tsx
+++ b/components/onboarding-banner.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { RefreshCw, X, Calendar } from 'lucide-react';
-import { API_BASE } from '@/lib/api';
+import { API_BASE, prepareGoogleLink } from '@/lib/api';
 
 const STORAGE_KEY = 'onboarding_dismissed';
 
@@ -19,9 +19,12 @@ export function OnboardingBanner() {
     setVisible(false);
   };
 
-  const handleSync = () => {
+  const handleSync = async () => {
     dismiss();
     const base = API_BASE || 'http://localhost:8080';
+    // OAuth 리다이렉트 후 SecurityContext가 Google 사용자로 교체되므로
+    // 세션에 userId를 미리 저장해 두어야 handleGoogleLogin이 userId를 식별할 수 있음
+    await prepareGoogleLink();
     window.location.href = `${base}/oauth2/authorization/google`;
   };
 

--- a/components/protected-route.tsx
+++ b/components/protected-route.tsx
@@ -5,6 +5,7 @@ import { useEffect } from "react"
 import { useRouter, usePathname, useSearchParams } from "next/navigation"
 import { useAuth } from "@/context/auth-context"
 import { Suspense } from "react"
+import { SplashScreen } from "@/components/splash-screen"
 
 interface ProtectedRouteProps {
   children: React.ReactNode
@@ -25,14 +26,7 @@ function ProtectedRouteInner({ children }: ProtectedRouteProps) {
   }, [user, isLoading, router, pathname, searchParams])
 
   if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="text-center">
-          <div className="mb-4 inline-block h-8 w-8 animate-spin rounded-full border-4 border-primary border-r-transparent" />
-          <p className="text-foreground">로딩 중...</p>
-        </div>
-      </div>
-    )
+    return <SplashScreen />
   }
 
   if (!user) return null
@@ -42,11 +36,7 @@ function ProtectedRouteInner({ children }: ProtectedRouteProps) {
 
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
   return (
-    <Suspense fallback={
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-primary border-r-transparent" />
-      </div>
-    }>
+    <Suspense fallback={<SplashScreen />}>
       <ProtectedRouteInner>{children}</ProtectedRouteInner>
     </Suspense>
   )

--- a/components/splash-screen.tsx
+++ b/components/splash-screen.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function SplashScreen() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    // 최소 800ms 표시 후 페이드아웃
+    const timer = setTimeout(() => setVisible(false), 800);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <div
+      className={`fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-background transition-opacity duration-300 ${
+        visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      }`}
+    >
+      <div className="flex flex-col items-center gap-4">
+        <div className="h-20 w-20 rounded-3xl bg-primary/10 flex items-center justify-center shadow-sm">
+          <span className="text-4xl">📅</span>
+        </div>
+        <div className="text-center space-y-1">
+          <h1 className="text-2xl font-bold text-foreground">맞춰봄</h1>
+          <p className="text-sm text-muted-foreground">일정을 함께 조율해요</p>
+        </div>
+        <div className="mt-4 h-1 w-24 overflow-hidden rounded-full bg-primary/10">
+          <div className="h-full w-full origin-left animate-[loading_0.8s_ease-in-out_forwards] rounded-full bg-primary" />
+        </div>
+      </div>
+      <style jsx>{`
+        @keyframes loading {
+          from { transform: scaleX(0); }
+          to   { transform: scaleX(1); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/components/time-range-selector.tsx
+++ b/components/time-range-selector.tsx
@@ -58,15 +58,21 @@ export function TimeRangeSelector({
   }, [slotHeight]);
 
   // ── PC 포인터 드래그 ───────────────────────────────────────────────────────
+  // ref를 동기 설정해 stale closure 방지 (터치 핸들러와 동일한 패턴)
   const handlePointerDown = useCallback(
     (e: React.PointerEvent, hour: number) => {
       if (disabled || isMobile) return;
       e.preventDefault();
       e.stopPropagation();
+      const willSelect = !selectedSlots.includes(hour);
+      isDraggingRef.current = true;
+      dragStartIdxRef.current = hour;
+      dragEndIdxRef.current = hour;
+      dragTargetSelectedRef.current = willSelect;
       setIsDragging(true);
       setDragStartIdx(hour);
       setDragEndIdx(hour);
-      setDragTargetSelected(!selectedSlots.includes(hour));
+      setDragTargetSelected(willSelect);
       (e.target as HTMLElement).setPointerCapture(e.pointerId);
     },
     [disabled, selectedSlots, isMobile]
@@ -74,36 +80,42 @@ export function TimeRangeSelector({
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
-      if (!isDragging || !containerRef.current || isMobile) return;
+      // ref로 읽어 첫 move 이벤트에서 stale state(false)를 읽는 문제 방지
+      if (!isDraggingRef.current || !containerRef.current || isMobile) return;
       e.preventDefault();
       const rect = containerRef.current.getBoundingClientRect();
       const y = e.clientY - rect.top;
       const hour = Math.max(0, Math.min(23, Math.floor(y / slotHeight)));
+      dragEndIdxRef.current = hour;
       setDragEndIdx(hour);
     },
-    [isDragging, slotHeight, isMobile]
+    [slotHeight, isMobile]
   );
 
   const handlePointerUp = useCallback(
     (e: React.PointerEvent) => {
-      if (!isDragging || dragStartIdx === null || dragEndIdx === null || isMobile) {
+      if (!isDraggingRef.current || dragStartIdxRef.current === null || dragEndIdxRef.current === null || isMobile) {
+        isDraggingRef.current = false;
         setIsDragging(false);
         return;
       }
       (e.target as HTMLElement).releasePointerCapture(e.pointerId);
-      const start = Math.min(dragStartIdx, dragEndIdx);
-      const end = Math.max(dragStartIdx, dragEndIdx);
+      const start = Math.min(dragStartIdxRef.current, dragEndIdxRef.current);
+      const end = Math.max(dragStartIdxRef.current, dragEndIdxRef.current);
       const newSlots = new Set(selectedSlots);
       for (let i = start; i <= end; i++) {
-        if (dragTargetSelected) newSlots.add(i);
+        if (dragTargetSelectedRef.current) newSlots.add(i);
         else newSlots.delete(i);
       }
       onSlotsChange(Array.from(newSlots).sort((a, b) => a - b));
+      isDraggingRef.current = false;
+      dragStartIdxRef.current = null;
+      dragEndIdxRef.current = null;
       setIsDragging(false);
       setDragStartIdx(null);
       setDragEndIdx(null);
     },
-    [isDragging, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange, isMobile]
+    [selectedSlots, onSlotsChange, isMobile]
   );
 
   // ── 모바일 단일 탭 ─────────────────────────────────────────────────────────

--- a/components/time-range-selector.tsx
+++ b/components/time-range-selector.tsx
@@ -29,9 +29,12 @@ export function TimeRangeSelector({
   // 롱프레스 폴백용 상태 (토글 OFF일 때 사용)
   const [isMobileDragMode, setIsMobileDragMode] = useState(false);
 
-  // React state 배치 업데이트 타이밍 문제 우회용 ref
-  // (meeting-calendar의 monthDragRef 패턴과 동일)
+  // React state 배치 업데이트 타이밍 문제 우회용 ref (meeting-calendar 패턴)
+  // handleTouchEnd가 빠른 제스처 시 배치 커밋 전에 실행돼 stale state를 읽는 문제 방어
   const isDraggingRef = useRef(false);
+  const dragStartIdxRef = useRef<number | null>(null);
+  const dragEndIdxRef = useRef<number | null>(null);
+  const dragTargetSelectedRef = useRef<boolean>(false);
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -124,21 +127,31 @@ export function TimeRangeSelector({
       if (disabled || !isMobile) return;
 
       if (dragToggle) {
-        // 토글 ON: 즉시 드래그 시작 (ref로 동기 설정)
+        // 토글 ON: 즉시 드래그 시작
+        const willSelect = !selectedSlots.includes(hour);
+        // ref 동기 설정 (handleTouchEnd가 빠른 제스처에도 올바른 값을 읽도록)
         isDraggingRef.current = true;
+        dragStartIdxRef.current = hour;
+        dragEndIdxRef.current = hour;
+        dragTargetSelectedRef.current = willSelect;
+        // state 설정 (렌더링용 시각 피드백)
         setIsDragging(true);
         setDragStartIdx(hour);
         setDragEndIdx(hour);
-        setDragTargetSelected(!selectedSlots.includes(hour));
+        setDragTargetSelected(willSelect);
       } else {
         // 토글 OFF: 롱프레스 400ms 후 드래그 모드 진입
         longPressTimerRef.current = setTimeout(() => {
+          const willSelect = !selectedSlots.includes(hour);
           isDraggingRef.current = true;
+          dragStartIdxRef.current = hour;
+          dragEndIdxRef.current = hour;
+          dragTargetSelectedRef.current = willSelect;
           setIsMobileDragMode(true);
           setIsDragging(true);
           setDragStartIdx(hour);
           setDragEndIdx(hour);
-          setDragTargetSelected(!selectedSlots.includes(hour));
+          setDragTargetSelected(willSelect);
           if (navigator.vibrate) navigator.vibrate(30);
         }, 400);
       }
@@ -148,12 +161,12 @@ export function TimeRangeSelector({
 
   const handleTouchMove = useCallback(
     (e: React.TouchEvent) => {
-      // ref를 체크해 state 타이밍 문제 우회 (meeting-calendar 패턴)
       if (!isDraggingRef.current) return;
       e.preventDefault(); // 드래그 중 페이지 스크롤 차단
       const touch = e.touches[0];
       const hour = getHourFromY(touch.clientY);
-      setDragEndIdx(hour);
+      dragEndIdxRef.current = hour; // ref 동기 업데이트
+      setDragEndIdx(hour);          // state 업데이트 (렌더링용)
     },
     [getHourFromY]
   );
@@ -165,31 +178,38 @@ export function TimeRangeSelector({
         longPressTimerRef.current = null;
       }
 
-      if (isDraggingRef.current && dragStartIdx !== null && dragEndIdx !== null) {
-        const start = Math.min(dragStartIdx, dragEndIdx);
-        const end = Math.max(dragStartIdx, dragEndIdx);
+      // ref 값으로 계산 (state 배치 업데이트 타이밍 문제 완전 우회)
+      if (isDraggingRef.current && dragStartIdxRef.current !== null && dragEndIdxRef.current !== null) {
+        const start = Math.min(dragStartIdxRef.current, dragEndIdxRef.current);
+        const end = Math.max(dragStartIdxRef.current, dragEndIdxRef.current);
         const newSlots = new Set(selectedSlots);
         for (let i = start; i <= end; i++) {
-          if (dragTargetSelected) newSlots.add(i);
+          if (dragTargetSelectedRef.current) newSlots.add(i);
           else newSlots.delete(i);
         }
         onSlotsChange(Array.from(newSlots).sort((a, b) => a - b));
       }
 
       isDraggingRef.current = false;
+      dragStartIdxRef.current = null;
+      dragEndIdxRef.current = null;
+      dragTargetSelectedRef.current = false;
       setIsDragging(false);
       // 토글 ON이면 드래그 모드 유지 (다음 터치도 즉시 드래그)
       if (!dragToggle) setIsMobileDragMode(false);
       setDragStartIdx(null);
       setDragEndIdx(null);
     },
-    [dragToggle, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange]
+    [dragToggle, selectedSlots, onSlotsChange]
   );
 
   const handleDragToggleChange = (checked: boolean) => {
     setDragToggle(checked);
     if (!checked) {
       isDraggingRef.current = false;
+      dragStartIdxRef.current = null;
+      dragEndIdxRef.current = null;
+      dragTargetSelectedRef.current = false;
       setIsMobileDragMode(false);
       setIsDragging(false);
       setDragStartIdx(null);

--- a/components/time-range-selector.tsx
+++ b/components/time-range-selector.tsx
@@ -3,6 +3,7 @@
 import type React from 'react';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { cn } from '@/lib/utils';
+import { Switch } from '@/components/ui/switch';
 
 interface TimeRangeSelectorProps {
   selectedSlots: number[];
@@ -22,7 +23,8 @@ export function TimeRangeSelector({
   const [dragTargetSelected, setDragTargetSelected] = useState<boolean>(false);
   const [isMobile, setIsMobile] = useState(false);
 
-  // 모바일 롱프레스 드래그 모드
+  // 모바일 드래그 토글 (Switch로 즉시 활성화) + 롱프레스 폴백
+  const [dragToggle, setDragToggle] = useState(false);
   const [isMobileDragMode, setIsMobileDragMode] = useState(false);
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
   const touchStartHourRef = useRef<number | null>(null);
@@ -100,13 +102,13 @@ export function TimeRangeSelector({
   // ── 모바일 탭 (단일 선택) ────────────────────────────────────────────
   const handleSlotTap = useCallback(
     (hour: number) => {
-      if (disabled || isMobileDragMode) return;
+      if (disabled || isMobileDragMode || dragToggle) return;
       const newSlots = new Set(selectedSlots);
       if (newSlots.has(hour)) newSlots.delete(hour);
       else newSlots.add(hour);
       onSlotsChange(Array.from(newSlots).sort((a, b) => a - b));
     },
-    [disabled, selectedSlots, onSlotsChange, isMobileDragMode]
+    [disabled, selectedSlots, onSlotsChange, isMobileDragMode, dragToggle]
   );
 
   // ── 모바일 터치 드래그 ────────────────────────────────────────────────
@@ -115,18 +117,26 @@ export function TimeRangeSelector({
       if (disabled || !isMobile) return;
       touchStartHourRef.current = hour;
 
-      // 롱프레스 400ms → 드래그 모드 진입
-      longPressTimerRef.current = setTimeout(() => {
+      if (dragToggle) {
+        // 토글 ON: 즉시 드래그 모드 진입
         setIsMobileDragMode(true);
         setIsDragging(true);
         setDragStartIdx(hour);
         setDragEndIdx(hour);
         setDragTargetSelected(!selectedSlots.includes(hour));
-        // 진동 피드백 (지원 기기)
-        if (navigator.vibrate) navigator.vibrate(30);
-      }, 400);
+      } else {
+        // 토글 OFF: 롱프레스 400ms 후 드래그 모드 진입
+        longPressTimerRef.current = setTimeout(() => {
+          setIsMobileDragMode(true);
+          setIsDragging(true);
+          setDragStartIdx(hour);
+          setDragEndIdx(hour);
+          setDragTargetSelected(!selectedSlots.includes(hour));
+          if (navigator.vibrate) navigator.vibrate(30);
+        }, 400);
+      }
     },
-    [disabled, isMobile, selectedSlots]
+    [disabled, isMobile, dragToggle, selectedSlots]
   );
 
   const handleTouchMove = useCallback(
@@ -159,12 +169,13 @@ export function TimeRangeSelector({
       }
 
       setIsDragging(false);
-      setIsMobileDragMode(false);
+      // 토글 ON이면 드래그 모드 유지 (다음 터치도 즉시 드래그)
+      if (!dragToggle) setIsMobileDragMode(false);
       setDragStartIdx(null);
       setDragEndIdx(null);
       touchStartHourRef.current = null;
     },
-    [isMobileDragMode, isDragging, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange]
+    [isMobileDragMode, isDragging, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange, dragToggle]
   );
 
   const getSlotState = (
@@ -197,18 +208,26 @@ export function TimeRangeSelector({
     return ranges.join(', ');
   };
 
+  const handleDragToggleChange = (checked: boolean) => {
+    setDragToggle(checked);
+    if (!checked) {
+      setIsMobileDragMode(false);
+      setIsDragging(false);
+      setDragStartIdx(null);
+      setDragEndIdx(null);
+    }
+  };
+
   return (
     <div className="relative w-full">
-      {/* 모바일 안내 배너 */}
+      {/* 모바일 다중 선택 토글 (floating pill) */}
       {isMobile && (
-        <div className="mb-3 px-3 py-2.5 bg-primary/5 border border-primary/15 rounded-xl">
-          <p className="text-xs text-foreground/70 leading-relaxed">
-            <span className="font-medium text-foreground/90">탭</span>으로 단일 선택,{' '}
-            <span className="font-medium text-foreground/90">길게 누른 후 드래그</span>로 여러 시간대를 선택할 수 있어요.
-          </p>
-          {isMobileDragMode && (
-            <p className="text-xs text-primary font-medium mt-1">드래그 모드 활성</p>
-          )}
+        <div className="sm:hidden fixed bottom-20 right-4 z-50 flex items-center gap-2 px-3 py-2 rounded-full bg-background shadow-lg border border-border/60">
+          <span className="text-xs text-muted-foreground">다중 선택</span>
+          <Switch
+            checked={dragToggle}
+            onCheckedChange={handleDragToggleChange}
+          />
         </div>
       )}
 

--- a/components/time-range-selector.tsx
+++ b/components/time-range-selector.tsx
@@ -4,6 +4,7 @@ import type React from 'react';
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
+import { CalendarDays } from 'lucide-react';
 
 interface TimeRangeSelectorProps {
   selectedSlots: number[];
@@ -23,34 +24,37 @@ export function TimeRangeSelector({
   const [dragTargetSelected, setDragTargetSelected] = useState<boolean>(false);
   const [isMobile, setIsMobile] = useState(false);
 
-  // 모바일 드래그 토글 (Switch로 즉시 활성화) + 롱프레스 폴백
+  // Switch 토글 (사전 설정 — 클로저에서 항상 최신값 사용 가능)
   const [dragToggle, setDragToggle] = useState(false);
+  // 롱프레스 폴백용 상태 (토글 OFF일 때 사용)
   const [isMobileDragMode, setIsMobileDragMode] = useState(false);
+
+  // React state 배치 업데이트 타이밍 문제 우회용 ref
+  // (meeting-calendar의 monthDragRef 패턴과 동일)
+  const isDraggingRef = useRef(false);
   const longPressTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const touchStartHourRef = useRef<number | null>(null);
 
   const hours = Array.from({ length: 24 }, (_, i) => i);
   const slotHeight = 48;
 
   useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768 || 'ontouchstart' in window);
-    };
-    checkMobile();
-    window.addEventListener('resize', checkMobile);
-    return () => window.removeEventListener('resize', checkMobile);
+    const check = () => setIsMobile(window.innerWidth < 768 || 'ontouchstart' in window);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
   }, []);
 
-  const formatHour = (hour: number): string => `${hour.toString().padStart(2, '0')}:00`;
+  const formatHour = (hour: number) => `${hour.toString().padStart(2, '0')}:00`;
 
   const getHourFromY = useCallback((clientY: number): number => {
     if (!containerRef.current) return 0;
     const rect = containerRef.current.getBoundingClientRect();
+    // getBoundingClientRect()는 뷰포트 기준, clientY도 뷰포트 기준이므로 스크롤 보정 불필요
     const y = clientY - rect.top;
     return Math.max(0, Math.min(23, Math.floor(y / slotHeight)));
   }, [slotHeight]);
 
-  // ── PC 드래그 ──────────────────────────────────────────────────────────
+  // ── PC 포인터 드래그 ───────────────────────────────────────────────────────
   const handlePointerDown = useCallback(
     (e: React.PointerEvent, hour: number) => {
       if (disabled || isMobile) return;
@@ -99,7 +103,7 @@ export function TimeRangeSelector({
     [isDragging, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange, isMobile]
   );
 
-  // ── 모바일 탭 (단일 선택) ────────────────────────────────────────────
+  // ── 모바일 단일 탭 ─────────────────────────────────────────────────────────
   const handleSlotTap = useCallback(
     (hour: number) => {
       if (disabled || isMobileDragMode || dragToggle) return;
@@ -111,15 +115,17 @@ export function TimeRangeSelector({
     [disabled, selectedSlots, onSlotsChange, isMobileDragMode, dragToggle]
   );
 
-  // ── 모바일 터치 드래그 ────────────────────────────────────────────────
+  // ── 모바일 터치 드래그 ─────────────────────────────────────────────────────
+  // meeting-calendar의 day view 터치 드래그 패턴과 동일한 방식:
+  // - isDraggingRef(ref)로 동기 상태 추적 → handleTouchMove 클로저 타이밍 문제 해결
+  // - dragToggle(사전 설정 state)로 touch-none 적용 → 페이지 스크롤 방지
   const handleTouchStart = useCallback(
     (e: React.TouchEvent, hour: number) => {
       if (disabled || !isMobile) return;
-      touchStartHourRef.current = hour;
 
       if (dragToggle) {
-        // 토글 ON: 즉시 드래그 모드 진입
-        setIsMobileDragMode(true);
+        // 토글 ON: 즉시 드래그 시작 (ref로 동기 설정)
+        isDraggingRef.current = true;
         setIsDragging(true);
         setDragStartIdx(hour);
         setDragEndIdx(hour);
@@ -127,6 +133,7 @@ export function TimeRangeSelector({
       } else {
         // 토글 OFF: 롱프레스 400ms 후 드래그 모드 진입
         longPressTimerRef.current = setTimeout(() => {
+          isDraggingRef.current = true;
           setIsMobileDragMode(true);
           setIsDragging(true);
           setDragStartIdx(hour);
@@ -141,23 +148,24 @@ export function TimeRangeSelector({
 
   const handleTouchMove = useCallback(
     (e: React.TouchEvent) => {
-      if (!isMobileDragMode || !isDragging) return;
-      e.preventDefault(); // 스크롤 차단 (드래그 모드에서만)
+      // ref를 체크해 state 타이밍 문제 우회 (meeting-calendar 패턴)
+      if (!isDraggingRef.current) return;
+      e.preventDefault(); // 드래그 중 페이지 스크롤 차단
       const touch = e.touches[0];
       const hour = getHourFromY(touch.clientY);
       setDragEndIdx(hour);
     },
-    [isMobileDragMode, isDragging, getHourFromY]
+    [getHourFromY]
   );
 
   const handleTouchEnd = useCallback(
-    (e: React.TouchEvent) => {
+    (_e: React.TouchEvent) => {
       if (longPressTimerRef.current) {
         clearTimeout(longPressTimerRef.current);
         longPressTimerRef.current = null;
       }
 
-      if (isMobileDragMode && isDragging && dragStartIdx !== null && dragEndIdx !== null) {
+      if (isDraggingRef.current && dragStartIdx !== null && dragEndIdx !== null) {
         const start = Math.min(dragStartIdx, dragEndIdx);
         const end = Math.max(dragStartIdx, dragEndIdx);
         const newSlots = new Set(selectedSlots);
@@ -168,19 +176,28 @@ export function TimeRangeSelector({
         onSlotsChange(Array.from(newSlots).sort((a, b) => a - b));
       }
 
+      isDraggingRef.current = false;
       setIsDragging(false);
       // 토글 ON이면 드래그 모드 유지 (다음 터치도 즉시 드래그)
       if (!dragToggle) setIsMobileDragMode(false);
       setDragStartIdx(null);
       setDragEndIdx(null);
-      touchStartHourRef.current = null;
     },
-    [isMobileDragMode, isDragging, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange, dragToggle]
+    [dragToggle, dragStartIdx, dragEndIdx, dragTargetSelected, selectedSlots, onSlotsChange]
   );
 
-  const getSlotState = (
-    hour: number
-  ): 'selected' | 'unselected' | 'drag-select' | 'drag-deselect' => {
+  const handleDragToggleChange = (checked: boolean) => {
+    setDragToggle(checked);
+    if (!checked) {
+      isDraggingRef.current = false;
+      setIsMobileDragMode(false);
+      setIsDragging(false);
+      setDragStartIdx(null);
+      setDragEndIdx(null);
+    }
+  };
+
+  const getSlotState = (hour: number): 'selected' | 'unselected' | 'drag-select' | 'drag-deselect' => {
     if (isDragging && dragStartIdx !== null && dragEndIdx !== null) {
       const start = Math.min(dragStartIdx, dragEndIdx);
       const end = Math.max(dragStartIdx, dragEndIdx);
@@ -208,25 +225,23 @@ export function TimeRangeSelector({
     return ranges.join(', ');
   };
 
-  const handleDragToggleChange = (checked: boolean) => {
-    setDragToggle(checked);
-    if (!checked) {
-      setIsMobileDragMode(false);
-      setIsDragging(false);
-      setDragStartIdx(null);
-      setDragEndIdx(null);
-    }
-  };
-
   return (
     <div className="relative w-full">
-      {/* 모바일 다중 선택 토글 (floating pill) */}
+      {/* 모바일 전용 다중 선택 토글 (meeting-calendar day view와 동일한 floating pill 스타일) */}
       {isMobile && (
-        <div className="sm:hidden fixed bottom-20 right-4 z-50 flex items-center gap-2 px-3 py-2 rounded-full bg-background shadow-lg border border-border/60">
-          <span className="text-xs text-muted-foreground">다중 선택</span>
+        <div className={cn(
+          'sm:hidden fixed bottom-20 right-4 z-50',
+          'flex items-center gap-2 px-3 py-2 rounded-full shadow-lg border',
+          dragToggle
+            ? 'bg-primary text-primary-foreground border-primary'
+            : 'bg-background text-foreground border-border'
+        )}>
+          <CalendarDays className="h-3.5 w-3.5 flex-shrink-0" />
+          <span className="text-xs font-medium whitespace-nowrap">다중 선택</span>
           <Switch
             checked={dragToggle}
             onCheckedChange={handleDragToggleChange}
+            className="scale-75"
           />
         </div>
       )}
@@ -236,7 +251,9 @@ export function TimeRangeSelector({
         className={cn(
           'relative border border-border/60 rounded-xl overflow-hidden bg-muted/10',
           disabled && 'opacity-50 cursor-not-allowed',
-          isMobileDragMode && 'touch-none'
+          // dragToggle은 사전 설정 state → 타이밍 문제 없이 touch-none 즉시 적용
+          // (페이지 스크롤 방지, meeting-calendar의 dayDragMode ? 'touch-none' 패턴과 동일)
+          (dragToggle || isMobileDragMode) && 'touch-none'
         )}
         style={{ height: `${24 * slotHeight}px` }}
         onPointerMove={handlePointerMove}
@@ -277,7 +294,7 @@ export function TimeRangeSelector({
                 )}
                 style={{ top: `${hour * slotHeight}px`, height: `${slotHeight}px` }}
                 onPointerDown={(e) => handlePointerDown(e, hour)}
-                onClick={() => isMobile && !isMobileDragMode && handleSlotTap(hour)}
+                onClick={() => isMobile && handleSlotTap(hour)}
                 onTouchStart={(e) => handleTouchStart(e, hour)}
                 onTouchMove={handleTouchMove}
                 onTouchEnd={handleTouchEnd}
@@ -294,7 +311,7 @@ export function TimeRangeSelector({
         </div>
       </div>
 
-      {/* 선택된 시간대 */}
+      {/* 선택된 시간대 요약 */}
       <div className="mt-3 px-4 py-3 rounded-xl bg-muted/30 border border-border/40">
         <div className="text-xs font-medium text-foreground/60 mb-1">선택된 시간대</div>
         <div className="text-sm text-foreground/80">{getSelectedRangesText()}</div>

--- a/components/weekly-schedule.tsx
+++ b/components/weekly-schedule.tsx
@@ -470,8 +470,8 @@ export function WeeklySchedule() {
                         className="absolute left-0.5 right-0.5 rounded-md cursor-pointer overflow-hidden z-10 transition-all hover:brightness-90 active:scale-[0.98]"
                         style={{
                           ...style,
-                          backgroundColor: hexWithAlpha(slot.color, 0.5),
-                          borderLeft: `4px solid ${slot.color}`,
+                          backgroundColor: hexWithAlpha(slot.color, 0.18),
+                          borderLeft: `3px solid ${slot.color}`,
                           minHeight: '20px',
                         }}
                         onClick={(e) => {
@@ -479,18 +479,15 @@ export function WeeklySchedule() {
                           openEditDialog(slot);
                         }}
                       >
-                        <div className="px-1 pt-0.5 h-full flex flex-col">
-                          <p
-                            className="text-[10px] font-bold leading-tight truncate"
-                            style={{ color: slot.color }}
-                          >
+                        <div
+                          className="px-1 pt-0.5 h-full flex flex-col"
+                          style={{ backgroundColor: hexWithAlpha(slot.color, 0.72) }}
+                        >
+                          <p className="text-[10px] font-bold leading-tight truncate text-gray-900">
                             {slot.title}
                           </p>
                           {!isShort && (
-                            <p
-                              className="text-[9px] leading-none mt-0.5 font-medium"
-                              style={{ color: slot.color, opacity: 0.85 }}
-                            >
+                            <p className="text-[9px] leading-none mt-0.5 font-medium text-gray-800/80">
                               {slot.startTime}–{slot.endTime}
                             </p>
                           )}

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -99,16 +99,17 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     })();
   }, [fetchMe]);
 
-  // 로그인 완료 후 sessionStorage에 저장된 redirect 경로로 이동
+  // 로그인 완료 후 localStorage에 저장된 redirect 경로로 이동
   useEffect(() => {
     if (isLoading || !user) return;
     if (typeof window === 'undefined') return;
 
-    const redirectTo = sessionStorage.getItem('login_redirect');
+    const redirectTo = localStorage.getItem('login_redirect');
     if (redirectTo) {
-      sessionStorage.removeItem('login_redirect');
-      // 현재 이미 해당 경로에 있지 않을 때만 이동
-      if (pathname !== redirectTo && pathname === '/') {
+      localStorage.removeItem('login_redirect');
+      // 상대 경로만 허용 (오픈 리다이렉트 방지)
+      const isSafe = redirectTo.startsWith('/') && !redirectTo.startsWith('//');
+      if (isSafe && pathname !== redirectTo && pathname === '/') {
         router.replace(redirectTo);
       }
     }

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -78,7 +78,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     (async () => {
       // 로그인 후 BE가 ?code= 파라미터로 리다이렉트하면 access token 교환
-      if (typeof window !== 'undefined') {
+      // BE(JwtLoginSuccessHandler)는 항상 루트(/)에만 ?code=authCode 로 리다이렉트.
+      // 다른 경로의 ?code= 파라미터(모임 초대 코드 등)는 건드리지 않는다.
+      if (typeof window !== 'undefined' && window.location.pathname === '/') {
         const params = new URLSearchParams(window.location.search);
         const code = params.get('code');
         if (code) {

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -9,7 +9,7 @@ import React, {
   ReactNode,
 } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { API_BASE } from '@/lib/api';
+import { API_BASE, setAccessToken, getAccessToken, exchangeAuthCode } from '@/lib/api';
 import { useSseSync } from '@/hooks/useSseSync';
 
 type User = {
@@ -38,9 +38,18 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const fetchMe = useCallback(async () => {
     try {
+      const headers: Record<string, string> = {};
+      const token = getAccessToken();
+      if (token) headers['Authorization'] = `Bearer ${token}`;
+
       const res = await fetch(`${API_BASE}/api/auth/me`, {
         credentials: 'include',
+        headers,
       });
+
+      // rotate된 새 access token이 응답 헤더에 있으면 메모리에 저장
+      const newToken = res.headers.get('X-New-Access-Token');
+      if (newToken) setAccessToken(newToken);
 
       if (!res.ok) {
         setUser(null);
@@ -68,6 +77,21 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     (async () => {
+      // 로그인 후 BE가 ?code= 파라미터로 리다이렉트하면 access token 교환
+      if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search);
+        const code = params.get('code');
+        if (code) {
+          try {
+            const token = await exchangeAuthCode(code);
+            setAccessToken(token);
+          } catch (e) {
+            console.error('Auth code exchange failed', e);
+          }
+          // URL에서 code 파라미터 제거
+          window.history.replaceState({}, '', window.location.pathname);
+        }
+      }
       await fetchMe();
       setIsLoading(false);
     })();

--- a/hooks/useSseSync.tsx
+++ b/hooks/useSseSync.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { useEventRefresh } from '@/hooks/useEventRefresh';
-import { API_BASE } from '@/lib/api';
+import { API_BASE, getAccessToken } from '@/lib/api';
 import { toast } from '@/hooks/use-toast';
 
 /**
@@ -29,7 +29,13 @@ export function useSseSync(enabled: boolean) {
         esRef.current = null;
       }
 
-      const es = new EventSource(`${API_BASE}/api/sse/events`, {
+      // EventSource는 커스텀 헤더 불가 → access token을 쿼리 파라미터로 전달
+      const accessToken = getAccessToken();
+      const sseUrl = accessToken
+        ? `${API_BASE}/api/sse/events?token=${encodeURIComponent(accessToken)}`
+        : `${API_BASE}/api/sse/events`;
+
+      const es = new EventSource(sseUrl, {
         withCredentials: true,
       });
       esRef.current = es;
@@ -84,6 +90,9 @@ export function useSseSync(enabled: boolean) {
         es.close();
         esRef.current = null;
 
+        // enabled가 false로 바뀐 경우(로그아웃 등)엔 재연결하지 않음
+        if (!enabled) return;
+
         const delay = Math.min(
           1000 * Math.pow(2, retryCountRef.current),
           MAX_RETRY_DELAY_MS
@@ -91,7 +100,7 @@ export function useSseSync(enabled: boolean) {
         retryCountRef.current += 1;
 
         retryTimeoutRef.current = setTimeout(() => {
-          connect();
+          if (enabled) connect();
         }, delay);
       };
     }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -49,7 +49,7 @@ export async function exchangeAuthCode(code: string): Promise<string> {
   return data.accessToken as string;
 }
 
-async function apiFetch(input: string, init?: RequestInit) {
+async function apiFetch(input: string, init?: RequestInit, _retried = false) {
   const headers: Record<string, string> = {
     Accept: 'application/json',
     'Content-Type': 'application/json',
@@ -70,6 +70,22 @@ async function apiFetch(input: string, init?: RequestInit) {
   const newToken = res.headers.get('X-New-Access-Token');
   if (newToken) {
     _accessToken = newToken;
+  }
+
+  // 401 발생 시 1회 토큰 갱신 후 재시도
+  // (SSE 연결 등 동시 요청으로 인한 token rotation race condition 방어)
+  if (res.status === 401 && !_retried) {
+    try {
+      const refreshRes = await fetch(`${API_BASE}/api/auth/me`, {
+        credentials: 'include',
+      });
+      const refreshed = refreshRes.headers.get('X-New-Access-Token');
+      if (refreshRes.ok && refreshed) {
+        _accessToken = refreshed;
+        return apiFetch(input, init, true);
+      }
+    } catch {}
+    throw new Error('UNAUTHORIZED');
   }
 
   if (res.status === 401) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -27,16 +27,50 @@ export type AvailabilitySlotUpdatePayload = {
 export const API_BASE =
   process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
+// ── Access Token 메모리 저장소 ────────────────────────────────────────────────
+// httpOnly 쿠키 대신 JS 메모리에 보관 (CSRF 완전 차단, 카카오 인앱브라우저 쿠키 격리 우회)
+let _accessToken: string | null = null;
+
+export function setAccessToken(token: string | null) {
+  _accessToken = token;
+}
+
+export function getAccessToken(): string | null {
+  return _accessToken;
+}
+
+// ── 인증 코드 → Access Token 교환 ────────────────────────────────────────────
+export async function exchangeAuthCode(code: string): Promise<string> {
+  const res = await fetch(`${API_BASE}/api/auth/token?code=${code}`, {
+    method: 'POST',
+  });
+  if (!res.ok) throw new Error('AUTH_CODE_EXCHANGE_FAILED');
+  const data = await res.json();
+  return data.accessToken as string;
+}
+
 async function apiFetch(input: string, init?: RequestInit) {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    ...(init?.headers as Record<string, string> || {}),
+  };
+
+  if (_accessToken) {
+    headers['Authorization'] = `Bearer ${_accessToken}`;
+  }
+
   const res = await fetch(`${API_BASE}${input}`, {
     credentials: 'include',
     ...init,
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      ...(init?.headers || {}),
-    },
+    headers,
   });
+
+  // rotate된 새 access token이 응답 헤더에 있으면 메모리 갱신
+  const newToken = res.headers.get('X-New-Access-Token');
+  if (newToken) {
+    _accessToken = newToken;
+  }
 
   if (res.status === 401) {
     throw new Error('UNAUTHORIZED');

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -57,6 +57,25 @@ async function apiFetch(input: string, init?: RequestInit) {
   return res;
 }
 
+/* ===================== Auth helpers ===================== */
+
+/**
+ * 구글 캘린더 연동 전 호출.
+ * OAuth 리다이렉트 이후 SecurityContext가 Google OAuth2 사용자로 교체되므로
+ * 세션에 현재 userId를 미리 저장해 두어야 handleGoogleLogin이 userId를 식별할 수 있다.
+ */
+export async function prepareGoogleLink(): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/auth/prepare-google-link`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 /* ===================== Calendar APIs ===================== */
 
 export async function fetchAllCalendarEvents(): Promise<RawCalendarEvent[]> {

--- a/types/meeting.ts
+++ b/types/meeting.ts
@@ -80,6 +80,7 @@ export type ParticipantSettingsUpdateRequest = {
 export type MeetingParticipant = {
   userId: string;
   name: string;
+  profileImageUrl?: string | null;
   status: 'ACCEPTED' | 'PENDING' | 'DECLINED';
   timeStatuses: ParticipantTimeStatus[];
   reflectTimetable: boolean;


### PR DESCRIPTION
## 🪄 Description
모임 초대링크 비로그인 접근 시 401 toast 노출, 카카오톡 등 인앱브라우저 전역 감지 누락, 모임 후보 시간 드래그 stale closure 버그 3가지를 수정한다.

## ❤️ Changes

### 🌳 작업 사항
- [x] `app/meetings/join/page.tsx` — useAuth()로 인증 후에만 자동 참여 API 호출 (비로그인 시 UNAUTHORIZED toast 제거)
- [x] `components/inapp-browser-guard.tsx` — 전역 인앱브라우저 감지 컴포넌트 신규 생성
- [x] `app/layout.tsx` — InAppBrowserGuard 루트 레이아웃 추가
- [x] `components/time-range-selector.tsx` — 포인터 핸들러 ref 패턴 적용, stale closure 수정

## 🔍 상세 내용

### 이슈 1: 초대링크 401 toast
- JoinPageContent의 useEffect가 ProtectedRoute의 부모에 위치해 비로그인 상태에서도 즉시 API 호출
- useAuth()로 user/isLoading 확인 후 인증된 상태에서만 실행하도록 수정

### 이슈 2: 인앱브라우저 전역 감지
- 기존 감지 로직이 로그인 페이지에만 존재 → 로그인된 사용자는 배너 미노출
- Android: Intent URI로 Chrome 자동 전환, iOS: 주소 복사 배너
- /login 페이지는 자체 배너 있으므로 스킵

### 이슈 3: 드래그 stale closure
- handlePointerMove가 isDragging state 클로저를 읽어 첫 pointermove에서 stale false 반환
- 터치 핸들러와 동일하게 isDraggingRef 등 ref 패턴 포인터 핸들러에도 적용

Closes #78