### PR TITLE
refactor : npm 통일 및 AI 화면 제거 (#86)

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -9,19 +9,34 @@ env:
   AWS_REGION:   ${{ secrets.AWS_REGION }}
   ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
   ECR_REPO:     ${{ secrets.ECR_FE_REPO }}
+  NEXT_PUBLIC_API_BASE: https://matuabom.store
 
 jobs:
-  build-push-deploy:
+  build-test:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
       - name: Set up Docker Buildx
+        if: github.ref_name == 'main'
         uses: docker/setup-buildx-action@v3
 
       - name: Configure AWS credentials
+        if: github.ref_name == 'main'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -29,41 +44,27 @@ jobs:
           aws-region:            ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
+        if: github.ref_name == 'main'
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Resolve environment
-        id: env
-        run: |
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            echo "api_base=https://matuabom.store" >> $GITHUB_OUTPUT
-          else
-            echo "api_base=https://dev.matuabom.store" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Build and push image
+      - name: Build and push production image
+        if: github.ref_name == 'main'
         run: |
           IMAGE=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPO }}
           SHA=${{ github.sha }}
 
-          # main → :latest (프로덕션), develop → :dev-latest (개발)
-          # 동일 :latest 태그 공유 시 develop 빌드가 프로덕션 이미지를 덮어쓰는 문제 방지
-          if [ "${{ github.ref_name }}" = "main" ]; then
-            FLOAT_TAG="latest"
-          else
-            FLOAT_TAG="dev-latest"
-          fi
-
           docker build \
-            --build-arg NEXT_PUBLIC_API_BASE=${{ steps.env.outputs.api_base }} \
+            --build-arg NEXT_PUBLIC_API_BASE=${{ env.NEXT_PUBLIC_API_BASE }} \
             --no-cache \
             -t $IMAGE:$SHA \
-            -t $IMAGE:$FLOAT_TAG \
+            -t $IMAGE:latest \
             .
 
           docker push $IMAGE:$SHA
-          docker push $IMAGE:$FLOAT_TAG
+          docker push $IMAGE:latest
 
       - name: Prune old ECR images (keep latest 3)
+        if: github.ref_name == 'main'
         run: |
           IMAGE_DETAILS=$(aws ecr describe-images \
             --repository-name ${{ env.ECR_REPO }} \
@@ -88,10 +89,12 @@ jobs:
           done
 
       - name: Get GitHub Actions IP
+        if: github.ref_name == 'main'
         id: ip
         run: echo "ipv4=$(curl -s https://api.ipify.org)" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Security Group Allow
+        if: github.ref_name == 'main'
         run: |
           aws ec2 authorize-security-group-ingress \
             --group-id ${{ secrets.AWS_SG_ID }} \
@@ -139,7 +142,7 @@ jobs:
             docker image prune -f
 
       - name: Configure AWS Security Group Revoke
-        if: always() && steps.ip.outputs.ipv4 != ''
+        if: always() && github.ref_name == 'main' && steps.ip.outputs.ipv4 != ''
         run: |
           aws ec2 revoke-security-group-ingress \
             --group-id ${{ secrets.AWS_SG_ID }} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,9 @@ FROM node:20-alpine AS builder
 WORKDIR /app
 
 # 의존성 파일만 먼저 복사 (레이어 캐시 최대화)
-COPY package.json package-lock.json* pnpm-lock.yaml* ./
+COPY package.json package-lock.json ./
 
-RUN if [ -f pnpm-lock.yaml ]; then \
-      corepack enable && pnpm install --frozen-lockfile; \
-    elif [ -f package-lock.json ]; then \
-      npm ci; \
-    else \
-      npm install; \
-    fi
+RUN npm ci
 
 # 소스 복사
 COPY . .

--- a/app/ai/page.tsx
+++ b/app/ai/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function AIPage() {
-  redirect('/');
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,0 @@
-lockfileVersion: '9.0'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
﻿## 연관된 이슈
> #86

## 작업 내용
> 프론트엔드 패키지 매니저를 npm으로 통일하고, dev-latest/dev.matuabom.store 빌드 경로를 제거했습니다. 사용하지 않는 /ai 페이지와 pnpm lockfile도 제거했습니다.

### 스크린샷

### 리뷰 요구사항
- develop push 시 dev.matuabom.store 값이 빌드/배포되지 않는지 확인해주세요.

Closes #86
