### PR TITLE
fix : 모임 시간 제약 endTime 24:00:00 → 23:59:59 변환 (#91)

### DIFF
--- a/app/meetings/[id]/settings/page.tsx
+++ b/app/meetings/[id]/settings/page.tsx
@@ -75,7 +75,7 @@ export default function MeetingSettingsPage({
       } else {
         ranges.push({
           startTime: `${start.toString().padStart(2, '0')}:00:00`,
-          endTime: `${(end + 1).toString().padStart(2, '0')}:00:00`,
+          endTime: end + 1 >= 24 ? '23:59:59' : `${(end + 1).toString().padStart(2, '0')}:00:00`,
         });
         if (i < sorted.length) { start = sorted[i]; end = sorted[i]; }
       }

--- a/app/meetings/create/page.tsx
+++ b/app/meetings/create/page.tsx
@@ -39,7 +39,7 @@ function slotsToConstraints(slots: number[]) {
     } else {
       ranges.push({
         startTime: `${start.toString().padStart(2, '0')}:00:00`,
-        endTime: `${(end + 1).toString().padStart(2, '0')}:00:00`,
+        endTime: end + 1 >= 24 ? '23:59:59' : `${(end + 1).toString().padStart(2, '0')}:00:00`,
       });
       if (i < sorted.length) { start = sorted[i]; end = sorted[i]; }
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #91

## 📝 작업 내용
> 모임 생성/수정 시 시간 슬롯 마지막(23시)을 선택하면 `endTime: '24:00:00'`이 전송되어 BE에서 `InvalidValue for HourOfDay` 500 오류가 발생하던 문제를 수정합니다.
> `end + 1 >= 24`일 때 `'23:59:59'`를 반환하도록 `slotsToConstraints`, `slotsToTimeConstraints` 두 함수를 수정했습니다.

### ✨ 스크린샷

### 💬 리뷰 요구사항
- 23시 슬롯 포함 모임 생성/수정이 정상 동작하는지 확인

Closes #91