### PR TITLE
feature : 모임 일정 조율 일 뷰 UX 개선 (#94)

### DIFF
--- a/components/meeting-calendar.tsx
+++ b/components/meeting-calendar.tsx
@@ -589,7 +589,7 @@ export function MeetingCalendar({
     const currentSlots = generateDailySchedule(selectedDate);
 
     return (
-      <Card className="flex flex-col overflow-hidden shadow-lg h-full relative">
+      <Card className="flex flex-col shadow-lg h-full relative">
         {readonly && (
           <div className="px-3 py-2 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-200 dark:border-amber-800 flex items-center gap-2">
             <Lock className="h-4 w-4 text-amber-600" />
@@ -598,7 +598,7 @@ export function MeetingCalendar({
         )}
 
         {/* 헤더 */}
-        <div className="flex items-center justify-between bg-gradient-to-r from-primary/10 to-primary/5 p-3 shrink-0">
+        <div className="flex items-center justify-between bg-card bg-gradient-to-r from-primary/10 to-primary/5 p-3 shrink-0 sticky top-0 z-10 rounded-t-xl">
           <Button variant="ghost" size="icon" onClick={handleBackToMonth} className="hover:bg-primary/10">
             <ChevronLeft className="h-5 w-5" />
           </Button>
@@ -610,7 +610,7 @@ export function MeetingCalendar({
 
         {/* 스크롤 영역 - dayDragMode ON 시 터치 스크롤 차단 */}
         <div
-          className={cn('flex-1 relative', dayDragMode ? 'overflow-hidden touch-none' : 'overflow-y-auto')}
+          className={cn('flex-1 relative overflow-y-auto')}
           ref={scrollRef}
           onMouseUp={handleMouseUp}
           onMouseLeave={handleMouseUp}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #94

## 📝 작업 내용
> 모임 상세 페이지 일 뷰에서 두 가지 UX 개선

- 일 뷰 날짜/뒤로가기 헤더 sticky 고정: Card의 `overflow-hidden` 제거 + 헤더에 `sticky top-0 z-10` 적용
- 다중 선택 모드에서 왼쪽 시간 레이블 영역 터치 시 화면 스크롤 가능: `touch-none`/`overflow-hidden` 조건 제거, 슬롯의 `onTouchStart`에 `e.preventDefault()`로 오른쪽 드래그 선택은 유지

### ✨ 스크린샷

### 💬 리뷰 요구사항

Closes #94