### PR TITLE
feature : 개인정보/약관 1회 동의 게이트 (#104)

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-import { useEffect, Suspense, useState } from 'react';
+import { useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/context/auth-context';
 import { API_BASE } from '@/lib/api';
-import Link from 'next/link';
 
 function LoginPageContent() {
   const { user, isLoading } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get('redirect') || '/';
-  const [ageChecked, setAgeChecked] = useState(false);
 
   useEffect(() => {
     if (!isLoading && user) {
@@ -20,7 +18,6 @@ function LoginPageContent() {
   }, [isLoading, user, router, redirect]);
 
   const kakaoLogin = () => {
-    if (!ageChecked) return;
     if (redirect && redirect !== '/') {
       localStorage.setItem('login_redirect', redirect);
     }
@@ -43,22 +40,6 @@ function LoginPageContent() {
 
         {/* 로그인 */}
         <div className="space-y-3">
-          <label className="flex items-start gap-2.5 cursor-pointer select-none">
-            <input
-              type="checkbox"
-              checked={ageChecked}
-              onChange={(e) => setAgeChecked(e.target.checked)}
-              className="mt-0.5 h-4 w-4 rounded border-border accent-primary cursor-pointer flex-shrink-0"
-            />
-            <span className="text-xs text-muted-foreground leading-relaxed">
-              만 14세 이상이며{' '}
-              <Link href="/terms" className="underline hover:text-foreground">이용약관</Link>
-              {' '}및{' '}
-              <Link href="/privacy" className="underline hover:text-foreground">개인정보처리방침</Link>
-              에 동의합니다.
-            </span>
-          </label>
-
           {isLoading ? (
             <div className="flex items-center justify-center py-4">
               <div className="h-5 w-5 rounded-full border-2 border-primary border-r-transparent animate-spin" />
@@ -66,8 +47,7 @@ function LoginPageContent() {
           ) : (
             <button
               onClick={kakaoLogin}
-              disabled={!ageChecked}
-              className="w-full flex items-center justify-center gap-2.5 h-12 rounded-xl bg-[#FEE500] text-[#191919] font-semibold text-sm hover:bg-[#F5DC00] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              className="w-full flex items-center justify-center gap-2.5 h-12 rounded-xl bg-[#FEE500] text-[#191919] font-semibold text-sm hover:bg-[#F5DC00] transition-colors"
             >
               <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path fillRule="evenodd" clipRule="evenodd" d="M9 1C4.58172 1 1 3.80568 1 7.25C1 9.37033 2.27027 11.2412 4.22147 12.3836L3.39663 15.5547C3.33749 15.7784 3.59007 15.9547 3.78441 15.8237L7.5597 13.3938C8.02879 13.4632 8.51025 13.5 9 13.5C13.4183 13.5 17 10.6943 17 7.25C17 3.80568 13.4183 1 9 1Z" fill="#191919"/>

--- a/components/consent-gate.tsx
+++ b/components/consent-gate.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useAuth } from '@/context/auth-context';
+import { agreeTerms } from '@/lib/api';
+import { toast } from '@/hooks/use-toast';
+
+/**
+ * 약관/개인정보 동의 게이트.
+ * 로그인했지만 현재 약관 버전에 동의하지 않은 사용자에게만 1회 노출된다.
+ * 동의 시 서버에 기록(POST /api/auth/terms) 후 사용자 정보를 갱신해 게이트를 닫는다.
+ */
+export function ConsentGate() {
+  const { refreshUser, logout } = useAuth();
+  const [checked, setChecked] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleAgree = async () => {
+    if (!checked || submitting) return;
+    setSubmitting(true);
+    try {
+      await agreeTerms();
+      await refreshUser();
+    } catch {
+      toast({ title: '동의 처리에 실패했습니다. 다시 시도해주세요.', variant: 'destructive' });
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background p-6">
+      <div className="w-full max-w-sm space-y-6">
+        <div className="text-center space-y-1">
+          <h1 className="text-xl font-bold text-foreground">서비스 이용 동의</h1>
+          <p className="text-sm text-muted-foreground">맞춰봄 이용을 위해 동의가 필요해요.</p>
+        </div>
+
+        <label className="flex items-start gap-2.5 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
+            className="mt-0.5 h-4 w-4 rounded border-border accent-primary cursor-pointer flex-shrink-0"
+          />
+          <span className="text-xs text-muted-foreground leading-relaxed">
+            만 14세 이상이며{' '}
+            <Link href="/terms" className="underline hover:text-foreground">이용약관</Link>
+            {' '}및{' '}
+            <Link href="/privacy" className="underline hover:text-foreground">개인정보처리방침</Link>
+            에 동의합니다.
+          </span>
+        </label>
+
+        <button
+          onClick={handleAgree}
+          disabled={!checked || submitting}
+          className="w-full h-12 rounded-xl bg-primary text-primary-foreground font-semibold text-sm hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {submitting ? '처리 중...' : '동의하고 시작하기'}
+        </button>
+
+        <button
+          onClick={logout}
+          className="w-full text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          로그아웃
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/protected-route.tsx
+++ b/components/protected-route.tsx
@@ -6,6 +6,7 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation"
 import { useAuth } from "@/context/auth-context"
 import { Suspense } from "react"
 import { SplashScreen } from "@/components/splash-screen"
+import { ConsentGate } from "@/components/consent-gate"
 
 interface ProtectedRouteProps {
   children: React.ReactNode
@@ -30,6 +31,9 @@ function ProtectedRouteInner({ children }: ProtectedRouteProps) {
   }
 
   if (!user) return null
+
+  // 현재 약관 버전에 미동의한 사용자는 동의 게이트를 먼저 통과해야 함
+  if (user.termsAgreed === false) return <ConsentGate />
 
   return <>{children}</>
 }

--- a/context/auth-context.tsx
+++ b/context/auth-context.tsx
@@ -17,6 +17,7 @@ type User = {
   nickname: string;
   profileImageUrl?: string | null;
   createdAt?:string;
+  termsAgreed?: boolean;
 };
 
 type AuthContextType = {
@@ -61,7 +62,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         id: data.id,
         nickname: data.nickname,
         profileImageUrl: data.profileImageUrl,
-        createdAt: data.createdAt
+        createdAt: data.createdAt,
+        termsAgreed: data.termsAgreed,
       });
     } catch (e) {
       // 인증 실패 — 조용히 처리 (미로그인 상태는 정상)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -142,6 +142,11 @@ export async function prepareGoogleLink(): Promise<boolean> {
   }
 }
 
+/** 약관/개인정보 동의 기록 (최초 1회) */
+export async function agreeTerms(): Promise<void> {
+  await apiFetch('/api/auth/terms', { method: 'POST' });
+}
+
 /* ===================== Calendar APIs ===================== */
 
 export async function fetchAllCalendarEvents(): Promise<RawCalendarEvent[]> {


### PR DESCRIPTION
﻿## #️⃣ 연관된 이슈
> #104

## 📝 작업 내용
> 개인정보/약관 1회 동의 게이트

- 로그인 페이지에서 동의 체크박스/게이팅 제거 (버튼 항상 활성)
- ConsentGate 컴포넌트 추가 → 동의 시 POST /api/auth/terms 기록 후 사용자 갱신
- ProtectedRoute: user.termsAgreed === false일 때만 게이트 노출 (미배포/undefined면 미노출로 안전)
- auth-context User.termsAgreed 반영, lib/api.agreeTerms 추가

## ⚠️ 머지 순서
BE #100(동의 API/필드) 배포 후 머지. (BE 선행: ALTER TABLE → BE 머지 → FE 머지)

Closes #104
