### PR TITLE
fix : 모임 월간 화면 가능 인원수를 동시 가능 시간 기준으로 수정 (#106)

### DIFF
--- a/components/meeting-calendar.tsx
+++ b/components/meeting-calendar.tsx
@@ -194,19 +194,24 @@ export function MeetingCalendar({
       });
     }
 
+    // 후보 시간대별로 '동시에 가능한 인원수'를 구해 그 날의 최댓값을 사용한다.
+    // (일간 화면의 시간대별 교집합 기준과 일치 — 전원이 동시에 되는 시간이 있어야 '전원 가능')
+    const acceptedParticipants = meeting.participants.filter((p) => p.status !== 'PENDING');
+    const pendingCount = meeting.participants.length - acceptedParticipants.length;
+
     let availableCount = 0;
-    meeting.participants.forEach((participant) => {
-      if (participant.status === 'PENDING') return;
-      const effectiveTs = participant.userId === currentUserId
-        ? localParticipant?.timeStatuses?.find(t => t.date === dateKey)
-        : participant.timeStatuses?.find((t) => t.date === dateKey);
-      const impossibleSlots = effectiveTs?.impossibleSlots || [];
-      if (candidateHours.some((hour) => !impossibleSlots.includes(hour))) {
-        availableCount++;
-      }
+    candidateHours.forEach((hour) => {
+      let simultaneous = 0;
+      acceptedParticipants.forEach((participant) => {
+        const effectiveTs = participant.userId === currentUserId
+          ? localParticipant?.timeStatuses?.find((t) => t.date === dateKey)
+          : participant.timeStatuses?.find((t) => t.date === dateKey);
+        const impossibleSlots = effectiveTs?.impossibleSlots || [];
+        if (!impossibleSlots.includes(hour)) simultaneous++;
+      });
+      if (simultaneous > availableCount) availableCount = simultaneous;
     });
 
-    const pendingCount = meeting.participants.filter((p) => p.status === 'PENDING').length;
     return {
       availableCount,
       totalParticipants: totalCount,


### PR DESCRIPTION
## 변경 사항
모임 월간 캘린더의 날짜별 가능 인원수/색상 계산(`getDailyStats`)을 일간 화면과 동일한 기준으로 수정.

### 문제
- 기존: "참여자 각자가 그날 빈 시간이 1시간이라도 있는지"(사람별 OR)로 인원수를 셈
- 결과: 전원이 동시에 가능한 시간이 없어도 `n/n` 초록(전원 가능)으로 표시 (예: 6/25)

### 수정
- 후보 시간대별로 "동시에 가능한 인원수"를 구해 그 날의 최댓값을 `availableCount`로 사용
- `isFullyAvailable`(초록)은 그 최댓값이 전체 인원과 같고 PENDING이 0명일 때만 true
- → 6/25는 동시 가능 인원 최댓값(5)으로 표시되어 노랑으로 변경됨

## 비고
- BE `GET /api/meetings/{id}/daily-availability`(`isParticipantAvailableOnDate`)도 동일한 기준 문제가 있으나, 월간 셀은 이 응답을 사용하지 않아 이번 수정 범위에서 제외. BE 정합성은 별도 처리.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)
