### PR TITLE
refactor : 미사용 daily-availability 호출/타입 제거 (#108)

### DIFF
--- a/components/meeting-calendar.tsx
+++ b/components/meeting-calendar.tsx
@@ -9,14 +9,12 @@ import { Card } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import {
-  fetchDailyAvailability,
   patchParticipantAvailability,
   type AvailabilitySlotUpdatePayload,
 } from '@/lib/api';
 import type {
   Meeting,
   TimeSlotAvailability,
-  DailyCountDto,
   ParticipantTimeStatus,
   MeetingParticipant,
 } from '@/types/meeting';
@@ -48,7 +46,6 @@ export function MeetingCalendar({
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [view, setView] = useState<'month' | 'day'>('month');
-  const [dailyStats, setDailyStats] = useState<Record<string, DailyCountDto>>({});
 
   // 로컬 participant 상태 - PATCH 후 즉각 반영용
   const [localParticipant, setLocalParticipant] = useState<MeetingParticipant | null>(null);
@@ -150,20 +147,10 @@ export function MeetingCalendar({
     [meeting, currentParticipant, todayStatus, totalParticipants, currentUserId]
   );
 
-  const loadDailyAvailability = useCallback(async () => {
-    try {
-      const stats = await fetchDailyAvailability(meeting.id);
-      setDailyStats(stats);
-    } catch {
-      toast({ title: '가용 시간 정보를 불러오지 못했습니다.', variant: 'destructive' });
-    }
-  }, [meeting.id]);
-
   useEffect(() => {
     const initialDate = new Date(meeting.requirement.dateRangeStart);
     setCurrentMonth(new Date(initialDate.getFullYear(), initialDate.getMonth(), 1));
-    loadDailyAvailability();
-  }, [meeting.id, loadDailyAvailability]);
+  }, [meeting.id]);
 
   useEffect(() => {
     if (view === 'day' && scrollRef.current) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -6,7 +6,6 @@ import type {
   ParticipantSettingsUpdateRequest,
   AvailableSlot,
   ParticipantTimeStatus,
-  DailyCountDto,
   MeetingStatusUpdateRequest,
 } from '@/types/meeting';
 
@@ -258,15 +257,6 @@ export async function fetchAvailableSlots(
   id: string
 ): Promise<AvailableSlot[]> {
   const res = await apiFetch(`/api/meetings/${id}/available-slots`, {
-    method: 'GET',
-  });
-  return res.json();
-}
-
-export async function fetchDailyAvailability(
-  id: string
-): Promise<Record<string, DailyCountDto>> {
-  const res = await apiFetch(`/api/meetings/${id}/daily-availability`, {
     method: 'GET',
   });
   return res.json();

--- a/types/meeting.ts
+++ b/types/meeting.ts
@@ -31,12 +31,6 @@ export type AvailableSlot = {
   end: string; // ISO 8601 Instant
 };
 
-export type DailyCountDto = {
-  date: string; // "yyyy-MM-dd"
-  totalParticipants: number;
-  availableParticipants: number;
-};
-
 export interface ParticipantTimeStatus {
   date: string; // "YYYY-MM-DD"
   impossibleSlots: number[]; // JSON 전송 시 배열


### PR DESCRIPTION
## 변경 사항
응답을 화면에서 사용하지 않는 `GET /api/meetings/{id}/daily-availability` 호출과 관련 코드를 제거.

- `components/meeting-calendar.tsx`: `fetchDailyAvailability`/`DailyCountDto` import, `dailyStats` state, `loadDailyAvailability` 제거. useEffect는 초기 월(currentMonth) 설정만 유지.
- `lib/api.ts`: `fetchDailyAvailability` 함수 및 `DailyCountDto` import 제거
- `types/meeting.ts`: `DailyCountDto` 타입 제거

월간 셀은 클라이언트 계산(`getDailyStats`)을 사용하므로 화면 동작 변화 없음. tsc 통과.

## 비고
- 서버 측 엔드포인트/서비스 제거는 BE 레포에서 별도 PR로 처리.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
