### PR TITLE
fix : 모바일 탭 이동 시 화면 멈춤 (SSE 재연결 폭주) 수정 (#110)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -70,12 +70,12 @@ export default function RootLayout({
       <body className="font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <ErrorBoundary>
-            <AuthProvider>
-              <EventRefreshProvider>
+            <EventRefreshProvider>
+              <AuthProvider>
                 {children}
                 <Toaster />
-              </EventRefreshProvider>
-            </AuthProvider>
+              </AuthProvider>
+            </EventRefreshProvider>
           </ErrorBoundary>
         </ThemeProvider>
       </body>

--- a/hooks/useEventRefresh.tsx
+++ b/hooks/useEventRefresh.tsx
@@ -19,6 +19,19 @@ const EventRefreshContext = createContext<EventRefreshContextValue | null>(
   null
 );
 
+// Provider가 없을 때 반환하는 안정적인 fallback.
+// 매 렌더마다 새 객체/함수를 만들면 이를 의존성으로 쓰는 effect(useSseSync 등)가
+// 무한 재실행되므로, 정체성이 고정된 모듈 레벨 상수로 둔다.
+const NOOP_REFRESH = () => {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn('useEventRefresh: EventRefreshProvider가 없습니다.');
+  }
+};
+const FALLBACK_VALUE: EventRefreshContextValue = {
+  trigger: 0,
+  refresh: NOOP_REFRESH,
+};
+
 type ProviderProps = {
   children: ReactNode;
 };
@@ -40,18 +53,6 @@ export function EventRefreshProvider({ children }: ProviderProps) {
 export function useEventRefresh(): EventRefreshContextValue {
   const ctx = useContext(EventRefreshContext);
 
-  // Provider가 없는 경우 fallback 값 반환 (페이지 새로고침 없이)
-  if (!ctx) {
-    return {
-      trigger: 0,
-      refresh: () => {
-        // fallback: 아무것도 하지 않음 (페이지 새로고침 방지)
-        if (process.env.NODE_ENV === 'development') {
-          console.warn('useEventRefresh: EventRefreshProvider가 없습니다.');
-        }
-      },
-    };
-  }
-
-  return ctx;
+  // Provider가 없는 경우 안정적인 fallback 값 반환 (정체성 고정 — effect 무한 재실행 방지)
+  return ctx ?? FALLBACK_VALUE;
 }


### PR DESCRIPTION
## 문제
모바일에서 홈/모임/친구 탭을 이동하다 보면 화면이 멈추고, 브라우저를 완전히 재시작해야 복구됨. (Safari는 증상 없음)

## 원인
`app/layout.tsx`의 Provider 순서가 뒤집혀 `AuthProvider`가 `EventRefreshProvider`를 바깥에서 감쌌다. `AuthProvider` 내부의 `useSseSync` → `useEventRefresh()`는 context가 아직 없어 fallback을 타는데, fallback이 매 렌더마다 새 `refresh` 함수를 반환 → `useSseSync`의 effect(`[enabled, refresh]`)가 끊임없이 재실행되어 EventSource를 close/open 반복 → 모바일 WebKit에서 누적되며 화면 멈춤.

> 서버 프로토콜은 HTTP/2 정상 확인(요청에 `:authority` 등 의사 헤더 존재) → 연결 개수 고갈이 아니라 재연결 폭주가 원인.

## 수정
1. `app/layout.tsx`: `EventRefreshProvider`가 `AuthProvider`를 감싸도록 순서 교정 → context 정상 제공 → 안정적인 `refresh`(useCallback) 사용 → SSE 1회만 연결.
2. `hooks/useEventRefresh.tsx`: fallback `refresh`를 모듈 레벨 상수로 고정 (provider 누락 시에도 정체성 불변 — 재발 방지).

tsc 통과.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)
