### PR TITLE
fix : 홈 페이지 중복 SSE 연결 제거 (#112)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,7 +40,7 @@ export default function HomePage() {
   const [colorMap, setColorMap] = useState<Map<string, string>>(new Map());
 
   const isMobile = useIsMobile();
-  const { trigger, refresh } = useEventRefresh();
+  const { trigger } = useEventRefresh();
   const { toast } = useToast();
 
   const initialLoadDoneRef = useRef(false);
@@ -97,59 +97,9 @@ export default function HomePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trigger]);
 
-  // SSE 부분 패치 — events-changed 이벤트만 여기서 처리
-  useEffect(() => {
-    let es: EventSource;
-    let retryTimeout: ReturnType<typeof setTimeout>;
-
-    const connect = () => {
-      const accessToken = getAccessToken();
-      const sseUrl = accessToken
-        ? `${API_BASE}/api/sse/events?token=${encodeURIComponent(accessToken)}`
-        : `${API_BASE}/api/sse/events`;
-
-      es = new EventSource(sseUrl, { withCredentials: true });
-
-      es.addEventListener('events-changed', (e: MessageEvent) => {
-        try {
-          const { changed, deletedIds } = JSON.parse(e.data) as {
-            changed: RawCalendarEvent[];
-            deletedIds: string[];
-          };
-          setEvents((prev) => {
-            let next = [...prev];
-            if (deletedIds?.length) {
-              next = next.filter((ev) => !deletedIds.includes(ev.id));
-            }
-            if (changed?.length) {
-              for (const raw of changed) {
-                const mapped = mapRawToCalendarEvent(raw, 0);
-                const idx = next.findIndex((ev) => ev.id === mapped.id);
-                if (idx >= 0) next[idx] = mapped;
-                else next.push(mapped);
-              }
-              next.sort((a, b) => a.startDate.getTime() - b.startDate.getTime());
-            }
-            return next;
-          });
-        } catch {
-          refresh();
-        }
-      });
-
-      es.onerror = () => {
-        es.close();
-        retryTimeout = setTimeout(connect, 5000);
-      };
-    };
-
-    connect();
-
-    return () => {
-      clearTimeout(retryTimeout);
-      es?.close();
-    };
-  }, [refresh]);
+  // SSE는 전역 useSseSync(AuthProvider) 한 곳에서만 연결한다.
+  // events-changed/updated 수신 시 refresh()로 trigger가 증가하면 위 [trigger] effect가 전체 재조회.
+  // (홈에서 별도 EventSource를 또 열면 모바일 WebKit의 도메인당 SSE 슬롯이 누적되어 화면 멈춤 유발)
 
   const handleMonthChange = useCallback(
     async (months: Date[]) => {


### PR DESCRIPTION
## 문제 (#110 후 재발)
모바일에서 홈/모임/친구 탭 이동 중 화면이 멈추고, 브라우저 재시작해야 복구.

## 원인
SSE가 두 곳에서 열림 — 전역 `useSseSync`(AuthProvider, 1회) + 홈 `app/page.tsx`가 마운트마다 추가로 EventSource 연결. 홈을 드나들 때마다 후자가 누적되고, iOS WebKit이 도메인당 SSE 슬롯(약 6개)을 닫아도 즉시 회수하지 않아 고갈 → 이후 요청(탭 이동 fetch 포함) 멈춤 → 재시작 필요. (서버는 HTTP/2 정상)

## 수정
- `app/page.tsx`의 중복 EventSource 제거. SSE는 전역 `useSseSync` 한 곳만 사용.
- 변경 이벤트는 전역 SSE의 `refresh()` → `trigger` 증가 → 홈의 `[trigger]` effect 전체 재조회로 기능 유지.
- SSE 연결이 앱 전체에 항상 1개만 유지됨.

tsc 통과.

## 검증
배포 후 데스크톱 Chrome DevTools → Network에서 `/api/sse/events`가 탭을 오가도 1개로 유지되는지 확인.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
