### PR TITLE
fix : iOS Chrome에서 홈 방문 후 하단 탭 이동 막힘 (startTransition 잼) (#114)

### DIFF
--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -7,7 +7,6 @@ import {
   useState,
   useMemo,
   useCallback,
-  useTransition,
 } from 'react';
 import { ChevronLeft, ChevronRight, X, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -258,8 +257,6 @@ export function Calendar({
   const touchStartPosRef = useRef<{ x: number; y: number } | null>(null);
   const dialogJustOpenedRef = useRef(false);
 
-  const [isPending, startTransition] = useTransition();
-
   // 성능 파라미터
   const INITIAL_BEFORE = 2;
   const INITIAL_AFTER = 2;
@@ -373,14 +370,12 @@ export function Calendar({
 
         const previousScrollHeight = container.scrollHeight;
 
-        startTransition(() => {
-          setDisplayMonths((prev) => {
-            const filtered = filterDuplicateMonths(prev, toAdd);
-            if (filtered.length === 0) return prev;
-            const newMonths = [...filtered, ...prev];
-            onMonthChangeRef.current?.(newMonths);
-            return newMonths;
-          });
+        setDisplayMonths((prev) => {
+          const filtered = filterDuplicateMonths(prev, toAdd);
+          if (filtered.length === 0) return prev;
+          const newMonths = [...filtered, ...prev];
+          onMonthChangeRef.current?.(newMonths);
+          return newMonths;
         });
 
         requestAnimationFrame(() => {
@@ -401,14 +396,12 @@ export function Calendar({
         for (let i = 1; i <= LOAD_CHUNK; i++) {
           toAdd.push(addMonths(last, i));
         }
-        startTransition(() => {
-          setDisplayMonths((prev) => {
-            const filtered = filterDuplicateMonths(prev, toAdd);
-            if (filtered.length === 0) return prev;
-            const newMonths = [...prev, ...filtered];
-            onMonthChangeRef.current?.(newMonths);
-            return newMonths;
-          });
+        setDisplayMonths((prev) => {
+          const filtered = filterDuplicateMonths(prev, toAdd);
+          if (filtered.length === 0) return prev;
+          const newMonths = [...prev, ...filtered];
+          onMonthChangeRef.current?.(newMonths);
+          return newMonths;
         });
       }
     },


### PR DESCRIPTION
## 문제
iOS Chrome에서 홈(캘린더)을 방문하면 이후 하단 탭(`BottomNav`) 이동이 막힘. 모임 상세/검색(`router.push`)은 동작하고, 그걸 거치면 탭이 다시 풀리며, 홈 재방문 시 또 막힘. 데스크톱/BlueStacks(Blink)·iOS Safari 정상, 시크릿에서도 재현(캐시 아님).

## 근본 원인 (결정적 단서: Link는 막히고 router.push는 됨)
- `BottomNav` = `<Link>` → Next.js가 내부적으로 **React transition**으로 네비게이션.
- 상세/검색/생성 = `router.push` → 비-transition → 안 막힘.
- 홈 캘린더만 무한스크롤 월 추가에 `useTransition`/`startTransition` 사용. 홈 진입 시 `scrollIntoView`가 스크롤을 유발 → month-append `startTransition` 발동 → **iOS WebKit 스케줄러에서 pending으로 남아** 이후 `<Link>`(transition) 탭 이동을 막음. `router.push`로 한 번 이동하면 잼 해소.

## 수정
`components/calendar.tsx`에서 `useTransition` 제거, `startTransition(() => setDisplayMonths(...))` → 직접 `setDisplayMonths(...)`. `isPending`은 미사용이라 영향 없음. (LOAD_CHUNK=1이라 동기 업데이트 영향 미미)

tsc 통과. 데스크톱/Safari는 원래 정상이라 재현 불가 → iOS Chrome 실기기 검증 필요.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
