### PR TITLE
fix : 하단 탭 이동을 router.push로 변경 (iOS Chrome Link 잼 회피) (#116)

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { Home, Calendar, Users, User } from 'lucide-react';
 
 export function BottomNav() {
   const pathname = usePathname();
+  const router = useRouter();
 
   const navItems = [
     { href: '/', icon: Home, label: '홈' },
@@ -23,9 +23,12 @@ export function BottomNav() {
           const Icon = item.icon;
           const isActive = pathname === item.href;
           return (
-            <Link
+            // <Link>(React transition 기반) 네비게이션이 iOS Chrome(WebKit)에서 간헐적으로
+            // 막히는 문제가 있어, 명령형 router.push로 이동한다. (router.push는 정상 동작 확인됨)
+            <button
               key={item.href}
-              href={item.href}
+              type="button"
+              onClick={() => { if (pathname !== item.href) router.push(item.href); }}
               className={`flex flex-1 flex-col items-center gap-0.5 py-2.5 transition-colors ${
                 isActive
                   ? 'text-primary'
@@ -34,7 +37,7 @@ export function BottomNav() {
             >
               <Icon className={`h-5 w-5 ${isActive ? 'stroke-[2.5]' : 'stroke-2'}`} />
               <span className={`text-[10px] font-medium ${isActive ? 'font-semibold' : ''}`}>{item.label}</span>
-            </Link>
+            </button>
           );
         })}
       </div>


### PR DESCRIPTION
## 문제
iOS Chrome에서 홈(캘린더) 방문 후 하단 탭(`BottomNav`, `<Link>`) 이동이 막힘. 모임 상세/검색(`router.push`)은 항상 동작하고, 그걸 거치면 탭이 다시 풀림. startTransition 제거(#114/#115)로도 미해결.

## 접근 — 사용자 기기에서 확인된 동작에 근거
`router.push`는 막힌 적이 없고 `<Link>`만 막힌다는 점이 일관되게 재현됨. 그래서 하단 탭도 막히는 `<Link>`(Next.js 내부 transition) 대신 **정상 동작하는 명령형 `router.push`**로 이동하도록 변경 → 문제 경로 자체를 회피.

## 수정
- `components/bottom-nav.tsx`: `<Link href>` → `<button onClick={() => router.push(href)}>` (`useRouter`).

tsc 통과.

## 비고
근본 원인(왜 홈 방문 후 `<Link>` transition 네비게이션이 iOS Chrome에서 멈추는지)은 데스크톱/Safari에서 재현 불가라 미확정. 본 변경은 재현된 동작 차이에 근거한 직접 수정이며 iOS Chrome 실기기 검증 필요.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
