### PR TITLE
fix : 하단 탭 backdrop-filter 제거 + z-index 상향 (iOS Chrome 터치 미반응) (#118)

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -15,8 +15,15 @@ export function BottomNav() {
   ];
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-sm border-t border-border/40"
-      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 8px)' }}
+    <nav className="fixed bottom-0 left-0 right-0 z-[100] bg-background border-t border-border/40"
+      style={{
+        paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 8px)',
+        // iOS WebKit에서 fixed + backdrop-filter 요소의 히트테스트가 깨져 탭이 안 먹는 문제 회피:
+        // backdrop-blur 제거(불투명 배경), z 상향, 독립 stacking context + 터치 보장
+        isolation: 'isolate',
+        touchAction: 'manipulation',
+        pointerEvents: 'auto',
+      }}
     >
       <div className="flex items-center justify-around pt-1">
         {navItems.map((item) => {


### PR DESCRIPTION
## 문제
iOS Chrome에서 홈(캘린더) 방문 후 하단 탭 이동이 막힘. `<Link>`→`router.push` 전환(#116/#117)으로도 미해결 → 핸들러가 아니라 **터치가 탭에 도달하지 못함**(히트테스트/compositing).

## 가설 (가장 유력, 독립 분석과 일치)
`BottomNav`가 `fixed` + `backdrop-blur-sm`(backdrop-filter). iOS WebKit은 fixed + backdrop-filter 요소의 히트테스트가 다른 compositing 레이어 생성/파괴 후 stale 되는 버그가 있음. 홈 캘린더가 스크롤 컨테이너 + `fixed inset-0 z-50` 오버레이 등 레이어를 만들고 부수면서 하단 탭 터치 영역이 iOS Chrome에서 깨짐. Safari/Blink는 정상.

## 수정 (`components/bottom-nav.tsx`)
- `backdrop-blur-sm` 제거 → 불투명 `bg-background`
- `z-50` → `z-[100]`
- `isolation: isolate` + `touch-action: manipulation` + `pointer-events: auto`

tsc 통과.

## 비고
데스크톱/Safari 재현 불가(iOS Chrome 한정)라 코드 확증 불가 → iOS Chrome 실기기 검증 필요. 미해결 시 "탭 onClick 발화 여부"를 화면 디버그로 직접 확인하는 단계로 진행.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
