### PR TITLE
refactor : 잘못된 가설로 건드린 변경 원복 (startTransition/nav 스타일)

### DIFF
--- a/components/bottom-nav.tsx
+++ b/components/bottom-nav.tsx
@@ -15,15 +15,8 @@ export function BottomNav() {
   ];
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-[100] bg-background border-t border-border/40"
-      style={{
-        paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 8px)',
-        // iOS WebKit에서 fixed + backdrop-filter 요소의 히트테스트가 깨져 탭이 안 먹는 문제 회피:
-        // backdrop-blur 제거(불투명 배경), z 상향, 독립 stacking context + 터치 보장
-        isolation: 'isolate',
-        touchAction: 'manipulation',
-        pointerEvents: 'auto',
-      }}
+    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-background/95 backdrop-blur-sm border-t border-border/40"
+      style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 8px)' }}
     >
       <div className="flex items-center justify-around pt-1">
         {navItems.map((item) => {

--- a/components/calendar.tsx
+++ b/components/calendar.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   useMemo,
   useCallback,
+  useTransition,
 } from 'react';
 import { ChevronLeft, ChevronRight, X, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -257,6 +258,8 @@ export function Calendar({
   const touchStartPosRef = useRef<{ x: number; y: number } | null>(null);
   const dialogJustOpenedRef = useRef(false);
 
+  const [isPending, startTransition] = useTransition();
+
   // 성능 파라미터
   const INITIAL_BEFORE = 2;
   const INITIAL_AFTER = 2;
@@ -370,12 +373,14 @@ export function Calendar({
 
         const previousScrollHeight = container.scrollHeight;
 
-        setDisplayMonths((prev) => {
-          const filtered = filterDuplicateMonths(prev, toAdd);
-          if (filtered.length === 0) return prev;
-          const newMonths = [...filtered, ...prev];
-          onMonthChangeRef.current?.(newMonths);
-          return newMonths;
+        startTransition(() => {
+          setDisplayMonths((prev) => {
+            const filtered = filterDuplicateMonths(prev, toAdd);
+            if (filtered.length === 0) return prev;
+            const newMonths = [...filtered, ...prev];
+            onMonthChangeRef.current?.(newMonths);
+            return newMonths;
+          });
         });
 
         requestAnimationFrame(() => {
@@ -396,12 +401,14 @@ export function Calendar({
         for (let i = 1; i <= LOAD_CHUNK; i++) {
           toAdd.push(addMonths(last, i));
         }
-        setDisplayMonths((prev) => {
-          const filtered = filterDuplicateMonths(prev, toAdd);
-          if (filtered.length === 0) return prev;
-          const newMonths = [...prev, ...filtered];
-          onMonthChangeRef.current?.(newMonths);
-          return newMonths;
+        startTransition(() => {
+          setDisplayMonths((prev) => {
+            const filtered = filterDuplicateMonths(prev, toAdd);
+            if (filtered.length === 0) return prev;
+            const newMonths = [...prev, ...filtered];
+            onMonthChangeRef.current?.(newMonths);
+            return newMonths;
+          });
         });
       }
     },


### PR DESCRIPTION
iOS Chrome 하단 탭 버그의 실제 원인은 click retarget(#121 onPointerDown으로 해결)이었음. 원인 추적 중 잘못된 가설로 바꾼 두 변경만 원복:
- calendar.tsx: useTransition/startTransition 복구 (스크롤 성능 최적화)
- bottom-nav.tsx: backdrop-blur/z-index/isolation 원복 (디자인 유지). onPointerDown 수정은 유지.

유지: provider 순서(#111), 홈 중복 SSE 제거(#113), button+router.push(#117), onPointerDown(#121) — 모두 실제 개선/수정이라 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)