### PR TITLE
fix : 일정 팝업 버튼 모바일 정렬 + 홈 경유 시 탭 스크롤 상단 고정 (#126)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/context/auth-context';
 import { EventRefreshProvider } from '@/hooks/useEventRefresh';
 import { Toaster } from '@/components/ui/toaster';
 import { ErrorBoundary } from '@/components/error-boundary';
+import { ScrollToTop } from '@/components/scroll-to-top';
 import './globals.css';
 
 const _geist = Geist({ subsets: ['latin'] });
@@ -68,6 +69,7 @@ export default function RootLayout({
         />
       </head>
       <body className="font-sans antialiased">
+        <ScrollToTop />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <ErrorBoundary>
             <EventRefreshProvider>

--- a/components/event-dialog.tsx
+++ b/components/event-dialog.tsx
@@ -237,7 +237,7 @@ export function EventDialog({
           </div>
         </div>
 
-        <DialogFooter className="flex flex-row items-center gap-2 px-5 pb-5 pt-0">
+        <DialogFooter className="flex flex-row items-center justify-end gap-2 px-5 pb-5 pt-0">
           {event && (
             <button
               onClick={handleDelete}

--- a/components/scroll-to-top.tsx
+++ b/components/scroll-to-top.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+/**
+ * 라우트 변경 시 스크롤을 맨 위로 리셋한다.
+ * 홈(`/`)은 캘린더가 현재 달로 자체 스크롤하므로 제외한다.
+ * (홈 캘린더가 window를 아래로 스크롤해둔 상태가 다음 탭으로 이어지는 문제 방지)
+ */
+export function ScrollToTop() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (pathname === '/') return;
+    window.scrollTo(0, 0);
+    document.querySelectorAll('main').forEach((m) => m.scrollTo({ top: 0 }));
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## 1. 일정 팝업 버튼 모바일 좌측 쏠림
DialogFooter에 justify-end 누락 → shadcn 기본 sm:justify-end가 PC만 적용. justify-end 추가로 모바일도 우측 정렬.

## 2. 홈 경유 시 탭 상단 안 보임
window 스크롤(min-h-screen)이 홈 캘린더 scrollIntoView로 내려간 채 다음 탭으로 이어짐. ScrollToTop으로 라우트 변경 시 상단 리셋(홈 제외).

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)